### PR TITLE
Add debt/equity ratio feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,19 +19,26 @@ def format_market_cap(value):
 def get_stock_data(symbol):
     quote_url = f"https://financialmodelingprep.com/api/v3/quote/{symbol}?apikey={API_KEY}"
     profile_url = f"https://financialmodelingprep.com/api/v3/profile/{symbol}?apikey={API_KEY}"
+    ratios_url = f"https://financialmodelingprep.com/api/v3/ratios-ttm/{symbol}?apikey={API_KEY}"
 
     try:
         # Get quote data
         quote_response = requests.get(quote_url, timeout=10)
         quote_data = quote_response.json()
         if not isinstance(quote_data, list) or len(quote_data) == 0:
-            return None, None, None, None, None, None, None, None
+            return None, None, None, None, None, None, None, None, None
         quote = quote_data[0]
 
         # Get profile data
         profile_response = requests.get(profile_url, timeout=10)
         profile_data = profile_response.json()
         profile = profile_data[0] if isinstance(profile_data, list) and len(profile_data) > 0 else {}
+
+        ratio_response = requests.get(ratios_url, timeout=10)
+        ratio_data = ratio_response.json()
+        debt_to_equity = None
+        if isinstance(ratio_data, list) and len(ratio_data) > 0:
+            debt_to_equity = ratio_data[0].get("debtEquityRatioTTM")
 
         name = profile.get("companyName", "")
         logo_url = profile.get("image", "")
@@ -43,7 +50,17 @@ def get_stock_data(symbol):
         eps = quote.get("eps")
         market_cap = format_market_cap(quote.get("marketCap"))
 
-        return name, logo_url, sector, industry, exchange, price, eps, market_cap
+        return (
+            name,
+            logo_url,
+            sector,
+            industry,
+            exchange,
+            price,
+            eps,
+            market_cap,
+            debt_to_equity,
+        )
     except Exception as e:
         print(f"API error: {e}")
         return None, None, None, None, None, None, None, None, None
@@ -51,7 +68,7 @@ def get_stock_data(symbol):
 @app.route("/", methods=["GET", "POST"])
 def index():
     symbol = ""
-    price = eps = pe_ratio = valuation = company_name = logo_url = market_cap = sector = industry = exchange = error_message = None
+    price = eps = pe_ratio = valuation = company_name = logo_url = market_cap = sector = industry = exchange = debt_to_equity = error_message = None
 
     if request.method == "POST":
         symbol = request.form["ticker"].upper()
@@ -65,6 +82,7 @@ def index():
                 price,
                 eps,
                 market_cap,
+                debt_to_equity,
             ) = get_stock_data(symbol)
 
             if price is not None and eps:
@@ -77,6 +95,8 @@ def index():
                     valuation = "Fairly Valued"
             elif price is None or eps is None:
                 error_message = "Price or EPS data is missing."
+            if debt_to_equity is not None:
+                debt_to_equity = round(debt_to_equity, 2)
         except Exception as e:
             error_message = str(e)
 
@@ -93,6 +113,7 @@ def index():
         sector=sector,
         industry=industry,
         exchange=exchange,
+        debt_to_equity=debt_to_equity,
         error_message=error_message,
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 yfinance
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -52,6 +52,9 @@
                             <p><strong>P/E Ratio:</strong> {{ pe_ratio }}</p>
                             <p><strong>Valuation:</strong> {{ valuation }}</p>
                             <p><strong>Market Cap:</strong> {{ market_cap }}</p>
+                            {% if debt_to_equity %}
+                                <p><strong>Debt/Equity Ratio:</strong> {{ debt_to_equity }}</p>
+                            {% endif %}
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add Financial Modeling Prep ratios API call
- compute and display debt to equity ratio
- list `requests` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685940873cfc83268837aa4949e19296