### PR TITLE
Add historical price chart

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>P/E Ratio Calculator</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="bg-light">
     <div class="container py-5">
@@ -54,6 +55,38 @@
                             <p><strong>Market Cap:</strong> {{ market_cap }}</p>
                             {% if debt_to_equity %}
                                 <p><strong>Debt/Equity Ratio:</strong> {{ debt_to_equity }}</p>
+                            {% endif %}
+
+                            {% if history_prices %}
+                                <div class="mt-4">
+                                    <canvas id="priceChart"></canvas>
+                                </div>
+                                <script>
+                                    const ctx = document.getElementById('priceChart').getContext('2d');
+                                    new Chart(ctx, {
+                                        type: 'line',
+                                        data: {
+                                            labels: {{ history_dates|tojson }},
+                                            datasets: [{
+                                                label: 'Price',
+                                                data: {{ history_prices|tojson }},
+                                                fill: false,
+                                                borderColor: 'rgba(75, 192, 192, 1)',
+                                                tension: 0.1
+                                            }]
+                                        },
+                                        options: {
+                                            scales: {
+                                                x: {
+                                                    title: { display: true, text: 'Date' }
+                                                },
+                                                y: {
+                                                    title: { display: true, text: 'Price' }
+                                                }
+                                            }
+                                        }
+                                    });
+                                </script>
                             {% endif %}
                         {% endif %}
                     </div>


### PR DESCRIPTION
## Summary
- fetch historical prices from FMP API
- display prices on a line chart using Chart.js

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685945d00a988326aed4aa4c6a2bac6a