### PR TITLE
Add alert for high P/E ratio

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,9 @@ app = Flask(__name__)
 
 API_KEY = "fM7Qz7WUnr08q65xIA720mnBnnLbUhav"
 
+# Threshold for triggering a P/E ratio alert
+ALERT_PE_THRESHOLD = 30
+
 
 def get_historical_prices(symbol, days=30):
     """Fetch historical closing prices for the given symbol."""
@@ -86,7 +89,7 @@ def get_stock_data(symbol):
 @app.route("/", methods=["GET", "POST"])
 def index():
     symbol = ""
-    price = eps = pe_ratio = valuation = company_name = logo_url = market_cap = sector = industry = exchange = debt_to_equity = error_message = None
+    price = eps = pe_ratio = valuation = company_name = logo_url = market_cap = sector = industry = exchange = debt_to_equity = error_message = alert_message = None
     history_dates = history_prices = []
 
     if request.method == "POST":
@@ -114,6 +117,10 @@ def index():
                     valuation = "Overvalued?"
                 else:
                     valuation = "Fairly Valued"
+                if pe_ratio > ALERT_PE_THRESHOLD:
+                    alert_message = (
+                        f"P/E ratio {pe_ratio} exceeds threshold of {ALERT_PE_THRESHOLD}"
+                    )
             elif price is None or eps is None:
                 error_message = "Price or EPS data is missing."
             if debt_to_equity is not None:
@@ -136,6 +143,7 @@ def index():
         exchange=exchange,
         debt_to_equity=debt_to_equity,
         error_message=error_message,
+        alert_message=alert_message,
         history_dates=history_dates,
         history_prices=history_prices,
     )

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,6 +51,9 @@
                             <p><strong>Price:</strong> {{ price }}</p>
                             <p><strong>EPS:</strong> {{ eps }}</p>
                             <p><strong>P/E Ratio:</strong> {{ pe_ratio }}</p>
+                            {% if alert_message %}
+                                <div class="alert alert-warning mt-2">{{ alert_message }}</div>
+                            {% endif %}
                             <p><strong>Valuation:</strong> {{ valuation }}</p>
                             <p><strong>Market Cap:</strong> {{ market_cap }}</p>
                             {% if debt_to_equity %}


### PR DESCRIPTION
## Summary
- alert when a company's P/E ratio is above a configurable threshold

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68594800b0c083269e1bfd635f780537