### PR TITLE
Add CSV and PDF export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 yfinance
 requests
 babel
+fpdf

--- a/templates/index.html
+++ b/templates/index.html
@@ -94,6 +94,10 @@
                                     });
                                 </script>
                             {% endif %}
+                            <div class="mt-3">
+                                <a href="{{ url_for('download', symbol=symbol, format='csv') }}" class="btn btn-secondary me-2">Download CSV</a>
+                                <a href="{{ url_for('download', symbol=symbol, format='pdf') }}" class="btn btn-secondary">Download PDF</a>
+                            </div>
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- let users download stock data as CSV or PDF
- add buttons to export results
- add `fpdf` to requirements

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68594be2ed748326b221b4f51e922e9b