### PR TITLE
Add search history

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,11 +22,23 @@
                             <div class="d-grid">
                                 <button type="submit" class="btn btn-primary">Fetch Live Data</button>
                             </div>
-                        </form>
+                            </form>
 
-                        {% if error_message %}
-                            <div class="alert alert-danger mt-4">{{ error_message }}</div>
-                        {% endif %}
+                            {% if history %}
+                                <div class="mt-3">
+                                    <h5>Search History</h5>
+                                    <ul class="list-group">
+                                    {% for item in history %}
+                                        <li class="list-group-item">{{ item }}</li>
+                                    {% endfor %}
+                                    </ul>
+                                    <a href="{{ url_for('clear_history') }}" class="btn btn-sm btn-danger mt-2">Clear History</a>
+                                </div>
+                            {% endif %}
+
+                            {% if error_message %}
+                                <div class="alert alert-danger mt-4">{{ error_message }}</div>
+                            {% endif %}
 
                         {% if pe_ratio %}
                             <hr>


### PR DESCRIPTION
## Summary
- keep track of ticker searches in the user session
- add ability to clear the saved history
- display past searches on the home page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68594d6a4c4483269891d537166c4e98