### PR TITLE
Add user authentication with watchlists

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ yfinance
 requests
 babel
 fpdf
+Flask-Login
+Flask-SQLAlchemy

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,19 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="bg-light">
+    <nav class="navbar navbar-light bg-white shadow-sm">
+        <div class="container">
+            {% if current_user.is_authenticated %}
+                <span class="navbar-text me-2">Logged in as {{ current_user.username }}</span>
+                <a href="{{ url_for('watchlist') }}" class="btn btn-sm btn-outline-primary me-2">Watchlist</a>
+                <a href="{{ url_for('export_history') }}" class="btn btn-sm btn-outline-secondary me-2">Export History</a>
+                <a href="{{ url_for('logout') }}" class="btn btn-sm btn-danger">Logout</a>
+            {% else %}
+                <a href="{{ url_for('login') }}" class="btn btn-sm btn-outline-primary me-2">Login</a>
+                <a href="{{ url_for('signup') }}" class="btn btn-sm btn-outline-secondary">Sign Up</a>
+            {% endif %}
+        </div>
+    </nav>
     <div class="container py-5">
         <div class="row justify-content-center">
             <div class="col-md-6 col-sm-12">
@@ -73,6 +86,9 @@
                             <p><strong>Market Cap:</strong> {{ market_cap }}</p>
                             {% if debt_to_equity %}
                                 <p><strong>Debt/Equity Ratio:</strong> {{ debt_to_equity }}</p>
+                            {% endif %}
+                            {% if current_user.is_authenticated and symbol %}
+                                <a href="{{ url_for('add_watchlist', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Watchlist</a>
                             {% endif %}
 
                             {% if history_prices %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <div class="row justify-content-center">
+            <div class="col-md-4 col-sm-12">
+                <div class="card shadow-sm">
+                    <div class="card-body">
+                        <h3 class="card-title text-center mb-4">Login</h3>
+                        {% if error %}
+                        <div class="alert alert-danger">{{ error }}</div>
+                        {% endif %}
+                        <form method="POST">
+                            <div class="mb-3">
+                                <label for="username" class="form-label">Username</label>
+                                <input type="text" name="username" class="form-control" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="password" class="form-label">Password</label>
+                                <input type="password" name="password" class="form-control" required>
+                            </div>
+                            <div class="d-grid">
+                                <button type="submit" class="btn btn-primary">Login</button>
+                            </div>
+                        </form>
+                        <div class="mt-3 text-center">
+                            <a href="{{ url_for('signup') }}">Sign Up</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sign Up</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <div class="row justify-content-center">
+            <div class="col-md-4 col-sm-12">
+                <div class="card shadow-sm">
+                    <div class="card-body">
+                        <h3 class="card-title text-center mb-4">Sign Up</h3>
+                        {% if error %}
+                        <div class="alert alert-danger">{{ error }}</div>
+                        {% endif %}
+                        <form method="POST">
+                            <div class="mb-3">
+                                <label for="username" class="form-label">Username</label>
+                                <input type="text" name="username" class="form-control" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="password" class="form-label">Password</label>
+                                <input type="password" name="password" class="form-control" required>
+                            </div>
+                            <div class="d-grid">
+                                <button type="submit" class="btn btn-primary">Sign Up</button>
+                            </div>
+                        </form>
+                        <div class="mt-3 text-center">
+                            <a href="{{ url_for('login') }}">Login</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Watchlist</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h3 class="mb-4">Watchlist</h3>
+        <form method="POST" class="mb-3">
+            <div class="input-group">
+                <input type="text" name="symbol" class="form-control" placeholder="Ticker symbol" required>
+                <button class="btn btn-primary" type="submit">Add</button>
+            </div>
+        </form>
+        {% if items %}
+        <ul class="list-group">
+            {% for item in items %}
+            <li class="list-group-item d-flex justify-content-between">
+                {{ item.symbol }}
+                <a href="{{ url_for('delete_watchlist_item', item_id=item.id) }}" class="btn btn-sm btn-danger">Delete</a>
+            </li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <p>No watchlist items.</p>
+        {% endif %}
+        <a href="{{ url_for('index') }}" class="btn btn-secondary mt-3">Back</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask-Login and SQLAlchemy dependencies
- configure database models and login management
- store search history and alerts in database when logged in
- allow user sign up, login/logout and watchlist management
- allow exporting history for authenticated users
- update UI with nav bar, new templates and watchlist button

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68594ff0c2d08326979f979bd80b7089