### PR TITLE
Add email alerts with scheduler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ babel
 fpdf
 Flask-Login
 Flask-SQLAlchemy
+APScheduler

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -22,6 +22,10 @@
                                 <input type="text" name="username" class="form-control" required>
                             </div>
                             <div class="mb-3">
+                                <label for="email" class="form-label">Email</label>
+                                <input type="email" name="email" class="form-control" required>
+                            </div>
+                            <div class="mb-3">
                                 <label for="password" class="form-label">Password</label>
                                 <input type="password" name="password" class="form-control" required>
                             </div>


### PR DESCRIPTION
## Summary
- collect user emails on signup
- schedule P/E ratio checks
- email users when watchlist stocks exceed threshold
- add APScheduler to requirements

## Testing
- `python -m py_compile app.py`
- `python -m pip install -r requirements.txt` *(fails: Could not find a version due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6859528db394832688d8795fa3072a1f