### PR TITLE
Enable Postgres with Flask-Login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Stock Analysis App
+
+This Flask application calculates P/E ratios and stores user data using SQLAlchemy. Authentication is handled via **Flask-Login**.
+
+## Database Configuration
+
+The app uses SQLite by default for local development. To deploy to platforms like Render with PostgreSQL, set a `DATABASE_URL` environment variable. When `DATABASE_URL` starts with `postgres://` it will automatically be converted to the `postgresql://` format expected by SQLAlchemy.
+
+Example:
+
+```bash
+export DATABASE_URL="postgres://user:password@hostname:5432/dbname"
+```
+
+If `DATABASE_URL` is not provided, a local `app.db` SQLite file will be used.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the application:
+
+```bash
+python app.py
+```
+

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from flask import (
     has_request_context,
     send_from_directory,
 )
+import os
 import requests
 from babel import Locale
 from babel.numbers import format_currency, format_decimal
@@ -34,7 +35,14 @@ import atexit
 
 app = Flask(__name__)
 app.config["SECRET_KEY"] = "change_this_secret"
-app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///app.db"
+
+# Use DATABASE_URL if provided (e.g. when deployed on Render), otherwise
+# default to a local SQLite database.
+db_url = os.environ.get("DATABASE_URL", "sqlite:///app.db")
+if db_url.startswith("postgres://"):
+    db_url = db_url.replace("postgres://", "postgresql://", 1)
+
+app.config["SQLALCHEMY_DATABASE_URI"] = db_url
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 app.config["SMTP_SERVER"] = "smtp.example.com"
 app.config["SMTP_PORT"] = 587

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Flask-Login
 Flask-SQLAlchemy
 APScheduler
 plotly
+psycopg2-binary


### PR DESCRIPTION
## Summary
- load `DATABASE_URL` env var to support PostgreSQL when deploying on Render
- update requirements with `psycopg2-binary`
- document database configuration in a new README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6859f2dfb8b483268124d28b10df0da4