### PR TITLE
Add scheduled user alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ When adding tickers to your watchlist you can specify a custom P/E ratio
 threshold for each stock. Alerts and warnings use this per-stock value. If no
 threshold is provided the default of 30 is used.
 
+## Scheduled Alerts
+
+Alert emails are sent on a schedule using **APScheduler**. Each user can
+configure how often their watchlist should be checked. Visit the *Settings*
+page after logging in to choose an alert frequency in hours. The default is 24
+hours. The background job runs hourly and only sends alerts when your selected
+interval has elapsed.
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,7 @@
                 <a href="{{ url_for('watchlist') }}" class="btn btn-sm btn-outline-primary me-2">Watchlist</a>
                 <a href="{{ url_for('favorites') }}" class="btn btn-sm btn-outline-primary me-2">Favorites</a>
                 <a href="{{ url_for('export_history') }}" class="btn btn-sm btn-outline-secondary me-2">Export History</a>
+                <a href="{{ url_for('settings') }}" class="btn btn-sm btn-outline-secondary me-2">Settings</a>
                 <a href="{{ url_for('logout') }}" class="btn btn-sm btn-danger">Logout</a>
             {% else %}
                 <a href="{{ url_for('login') }}" class="btn btn-sm btn-outline-primary me-2">Login</a>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Alert Settings</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h3 class="mb-4">Alert Settings</h3>
+        <form method="POST" class="mb-3" style="max-width:300px;">
+            <label class="form-label">Alert Frequency (hours)</label>
+            <input type="number" name="frequency" min="1" class="form-control" value="{{ frequency }}" required>
+            <button class="btn btn-primary mt-3" type="submit">Save</button>
+        </form>
+        <a href="{{ url_for('index') }}" class="btn btn-secondary">Back</a>
+    </div>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', function() {
+                navigator.serviceWorker.register('/service-worker.js');
+            });
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- store alert frequency and last sent time on users
- check alert settings in `check_watchlists`
- add settings page for per-user alert frequency
- link settings from navbar
- document scheduled alerts in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859f91c82e88326a5855497c37041db