### PR TITLE
Load config from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,27 @@ export DATABASE_URL="postgres://user:password@hostname:5432/dbname"
 
 If `DATABASE_URL` is not provided, a local `app.db` SQLite file will be used.
 
+## Environment Variables
+
+Several settings are loaded from environment variables so you do not need to
+store secrets in the source code:
+
+* `SECRET_KEY` &ndash; Flask session secret.
+* `API_KEY` &ndash; Financial Modeling Prep API key (required).
+* `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD` &ndash; SMTP
+  credentials for sending alert emails.
+
+Example:
+
+```bash
+export SECRET_KEY="supersecret"
+export API_KEY="your_fmp_api_key"
+export SMTP_SERVER="smtp.example.com"
+export SMTP_PORT=587
+export SMTP_USERNAME="user@example.com"
+export SMTP_PASSWORD="password"
+```
+
 ## Setup
 
 Install dependencies:

--- a/app.py
+++ b/app.py
@@ -34,7 +34,8 @@ from apscheduler.schedulers.background import BackgroundScheduler
 import atexit
 
 app = Flask(__name__)
-app.config["SECRET_KEY"] = "change_this_secret"
+# Load sensitive configuration from environment variables
+app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "change_this_secret")
 
 # Use DATABASE_URL if provided (e.g. when deployed on Render), otherwise
 # default to a local SQLite database.
@@ -44,10 +45,10 @@ if db_url.startswith("postgres://"):
 
 app.config["SQLALCHEMY_DATABASE_URI"] = db_url
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-app.config["SMTP_SERVER"] = "smtp.example.com"
-app.config["SMTP_PORT"] = 587
-app.config["SMTP_USERNAME"] = "user@example.com"
-app.config["SMTP_PASSWORD"] = "password"
+app.config["SMTP_SERVER"] = os.environ.get("SMTP_SERVER", "smtp.example.com")
+app.config["SMTP_PORT"] = int(os.environ.get("SMTP_PORT", 587))
+app.config["SMTP_USERNAME"] = os.environ.get("SMTP_USERNAME", "user@example.com")
+app.config["SMTP_PASSWORD"] = os.environ.get("SMTP_PASSWORD", "password")
 
 db = SQLAlchemy(app)
 
@@ -60,7 +61,9 @@ def service_worker():
 login_manager = LoginManager(app)
 login_manager.login_view = "login"
 
-API_KEY = "fM7Qz7WUnr08q65xIA720mnBnnLbUhav"
+API_KEY = os.environ.get("API_KEY")
+if not API_KEY:
+    raise RuntimeError("API_KEY environment variable not set")
 
 # Threshold for triggering a P/E ratio alert
 ALERT_PE_THRESHOLD = 30


### PR DESCRIPTION
## Summary
- read `SECRET_KEY`, SMTP config, and API key from environment variables
- document required environment variables in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6859fe203060832698357745da67e91d