### PR TITLE
Make debug mode configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ store secrets in the source code:
 * `API_KEY` &ndash; Financial Modeling Prep API key (required).
 * `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD` &ndash; SMTP
   credentials for sending alert emails.
+* `FLASK_DEBUG` &ndash; Set to `1` to enable Flask debug mode (defaults to `0`).
 
 Example:
 
@@ -33,6 +34,7 @@ export SMTP_SERVER="smtp.example.com"
 export SMTP_PORT=587
 export SMTP_USERNAME="user@example.com"
 export SMTP_PASSWORD="password"
+export FLASK_DEBUG=1
 ```
 
 ## Setup

--- a/app.py
+++ b/app.py
@@ -781,4 +781,5 @@ if __name__ == "__main__":
     scheduler.add_job(check_watchlists, "interval", hours=1)
     scheduler.start()
     atexit.register(lambda: scheduler.shutdown())
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    debug_mode = os.environ.get("FLASK_DEBUG", "0").lower() in ["1", "true", "yes"]
+    app.run(host="0.0.0.0", port=5000, debug=debug_mode)


### PR DESCRIPTION
## Summary
- make Flask debug mode configurable via `FLASK_DEBUG`
- document new environment variable in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685a074a35908326979960831c9e989f