### PR TITLE
Add CSRF protection to forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from babel.dates import format_datetime
 import csv
 import io
 from fpdf import FPDF
+from flask_wtf import CSRFProtect
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import (
     LoginManager,
@@ -51,6 +52,7 @@ app.config["SMTP_USERNAME"] = os.environ.get("SMTP_USERNAME", "user@example.com"
 app.config["SMTP_PASSWORD"] = os.environ.get("SMTP_PASSWORD", "password")
 
 db = SQLAlchemy(app)
+csrf = CSRFProtect(app)
 
 
 @app.route("/service-worker.js")
@@ -60,6 +62,11 @@ def service_worker():
 
 login_manager = LoginManager(app)
 login_manager.login_view = "login"
+
+@app.context_processor
+def inject_csrf_token():
+    from flask_wtf.csrf import generate_csrf
+    return dict(csrf_token=generate_csrf)
 
 API_KEY = os.environ.get("API_KEY")
 if not API_KEY:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ babel
 fpdf
 Flask-Login
 Flask-SQLAlchemy
+Flask-WTF
 APScheduler
 plotly
 psycopg2-binary

--- a/templates/favorites.html
+++ b/templates/favorites.html
@@ -11,6 +11,7 @@
     <div class="container py-5">
         <h3 class="mb-4">Favorite Tickers</h3>
         <form method="POST" class="mb-3">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="input-group">
                 <input type="text" name="symbol" class="form-control" placeholder="Ticker symbol" required>
                 <button class="btn btn-primary" type="submit">Add</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,7 @@
                     <div class="card-body">
                         <h3 class="card-title text-center mb-4">P/E Ratio Calculator</h3>
                         <form method="POST">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <div class="mb-3">
                                 <label for="ticker" class="form-label">Ticker Symbol:</label>
                                 <input type="text" id="ticker" name="ticker" value="{{ symbol }}" class="form-control" required>

--- a/templates/login.html
+++ b/templates/login.html
@@ -18,6 +18,7 @@
                         <div class="alert alert-danger">{{ error }}</div>
                         {% endif %}
                         <form method="POST">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <div class="mb-3">
                                 <label for="username" class="form-label">Username</label>
                                 <input type="text" name="username" class="form-control" required>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -11,6 +11,7 @@
     <div class="container py-5">
         <h3 class="mb-4">Alert Settings</h3>
         <form method="POST" class="mb-3" style="max-width:300px;">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <label class="form-label">Alert Frequency (hours)</label>
             <input type="number" name="frequency" min="1" class="form-control" value="{{ frequency }}" required>
             <button class="btn btn-primary mt-3" type="submit">Save</button>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -18,6 +18,7 @@
                         <div class="alert alert-danger">{{ error }}</div>
                         {% endif %}
                         <form method="POST">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <div class="mb-3">
                                 <label for="username" class="form-label">Username</label>
                                 <input type="text" name="username" class="form-control" required>

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -11,6 +11,7 @@
     <div class="container py-5">
         <h3 class="mb-4">Watchlist</h3>
         <form method="POST" class="mb-3">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="input-group">
                 <input type="text" name="symbol" class="form-control" placeholder="Ticker symbol" required>
                 <input type="number" step="0.01" name="threshold" class="form-control" placeholder="P/E threshold" value="{{ default_threshold }}">
@@ -22,6 +23,7 @@
             {% for item in items %}
             <li class="list-group-item">
                 <form method="POST" class="d-flex justify-content-between align-items-center">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div>
                         {{ item.symbol }}
                         <input type="hidden" name="item_id" value="{{ item.id }}">


### PR DESCRIPTION
## Summary
- secure forms with Flask-WTF
- add CSRF token context processor
- include CSRF tokens in all HTML templates

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685a0b67ae248326955e76d7f822b2ab