### PR TITLE
Fix CSRF token error with PWA cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ page after logging in to choose an alert frequency in hours. The default is 24
 hours. The background job runs hourly and only sends alerts when your selected
 interval has elapsed.
 
+## Progressive Web App Notes
+
+The app registers a small service worker so it can behave like a Progressive
+Web App. Only static assets are cached. The main pages are always fetched from
+the server so that dynamic CSRF tokens stay valid.
+

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,7 +1,5 @@
-const CACHE_NAME = 'pe-ratio-cache-v1';
+const CACHE_NAME = 'pe-ratio-cache-v2';
 const urlsToCache = [
-  '/',
-  '/index.html',
   '/static/manifest.json',
   '/static/icons/icon-192.png',
   '/static/icons/icon-512.png',


### PR DESCRIPTION
## Summary
- avoid caching the main page in service worker
- document how the service worker only caches static assets

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685a123013dc83268e0b36b564d910be