### PR TITLE
Fix CSRF error on stock search

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,8 +30,7 @@
                 <div class="card shadow-sm">
                     <div class="card-body">
                         <h3 class="card-title text-center mb-4">P/E Ratio Calculator</h3>
-                        <form method="POST">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <form method="GET">
                             <div class="mb-3">
                                 <label for="ticker" class="form-label">Ticker Symbol:</label>
                                 <input type="text" id="ticker" name="ticker" value="{{ symbol }}" class="form-control" required>


### PR DESCRIPTION
## Summary
- avoid CSRF by submitting search form via GET

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a16fe1a5c832697a0ba1acc565998