### PR TITLE
Fix stale cache causing CSRF error

### DIFF
--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -14,6 +14,17 @@ self.addEventListener('install', event => {
   );
 });
 
+// Remove old caches on activate so outdated HTML is not served
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
+    )
+  );
+});
+
 self.addEventListener('fetch', event => {
   event.respondWith(
     caches.match(event.request)


### PR DESCRIPTION
## Summary
- remove old caches when the service worker activates

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685a1ad5fdf48326a37aa379f7c76875