### PR TITLE
Expand financial metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ When adding tickers to your watchlist you can specify a custom P/E ratio
 threshold for each stock. Alerts and warnings use this per-stock value. If no
 threshold is provided the default of 30 is used.
 
+## Additional Metrics
+
+Alongside the standard P/E ratio the app now fetches and displays:
+
+* **Forward P/E** – estimated using the latest EPS growth data.
+* **Price-to-Sales (P/S) ratio** – retrieved from Financial Modeling Prep.
+
+These extra metrics appear on the main page and in exported CSV/PDF files.
+
 ## Scheduled Alerts
 
 Alert emails are sent on a schedule using **APScheduler**. Each user can

--- a/templates/index.html
+++ b/templates/index.html
@@ -111,6 +111,12 @@
                             {% if earnings_growth is not none %}
                                 <p><strong>Earnings Growth:</strong> {{ earnings_growth }}%</p>
                             {% endif %}
+                            {% if forward_pe is not none %}
+                                <p><strong>Forward P/E:</strong> {{ forward_pe }}</p>
+                            {% endif %}
+                            {% if price_to_sales is not none %}
+                                <p><strong>P/S Ratio:</strong> {{ price_to_sales }}</p>
+                            {% endif %}
                             {% if current_user.is_authenticated and symbol %}
                                 <a href="{{ url_for('add_watchlist', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Watchlist</a>
                                 <a href="{{ url_for('add_favorite', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Favorites</a>


### PR DESCRIPTION
## Summary
- fetch forward P/E and P/S ratio in `get_stock_data`
- display these metrics on the index page
- include new metrics when downloading data
- document new metrics in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a1f9692708326979f8121fe0fdd8b