### PR TITLE
Add alert history page

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ page after logging in to choose an alert frequency in hours. The default is 24
 hours. The background job runs hourly and only sends alerts when your selected
 interval has elapsed.
 
+## Viewing Alerts
+
+Triggered alerts are saved in the database. After logging in click the *Alerts* link to review them. The page also lets you clear old alerts.
+
 ## Progressive Web App Notes
 
 The app registers a small service worker so it can behave like a Progressive

--- a/app.py
+++ b/app.py
@@ -880,6 +880,25 @@ def settings():
     return render_template("settings.html", frequency=current_user.alert_frequency)
 
 
+@app.route("/alerts")
+@login_required
+def alerts():
+    entries = (
+        Alert.query.filter_by(user_id=current_user.id)
+        .order_by(Alert.timestamp.desc())
+        .all()
+    )
+    return render_template("alerts.html", alerts=entries)
+
+
+@app.route("/clear_alerts")
+@login_required
+def clear_alerts():
+    Alert.query.filter_by(user_id=current_user.id).delete()
+    db.session.commit()
+    return redirect(url_for("alerts"))
+
+
 @app.route("/export_history")
 @login_required
 def export_history():

--- a/templates/alerts.html
+++ b/templates/alerts.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Alerts</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h3 class="mb-4">Alert History</h3>
+        {% if alerts %}
+        <ul class="list-group">
+            {% for alert in alerts %}
+            <li class="list-group-item d-flex justify-content-between align-items-start">
+                <div>
+                    {{ alert.message }}
+                    {% if alert.symbol %}
+                        <span class="text-muted">({{ alert.symbol }})</span>
+                    {% endif %}
+                </div>
+                <small class="text-muted">{{ alert.timestamp.strftime('%Y-%m-%d %H:%M') }}</small>
+            </li>
+            {% endfor %}
+        </ul>
+        <a href="{{ url_for('clear_alerts') }}" class="btn btn-sm btn-danger mt-3">Clear Alerts</a>
+        {% else %}
+        <p>No alerts recorded.</p>
+        {% endif %}
+        <a href="{{ url_for('index') }}" class="btn btn-secondary mt-3">Back</a>
+    </div>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', function() {
+                navigator.serviceWorker.register('/service-worker.js');
+            });
+        }
+    </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,7 @@
                 <span class="navbar-text me-2">Logged in as {{ current_user.username }}</span>
                 <a href="{{ url_for('watchlist') }}" class="btn btn-sm btn-outline-primary me-2">Watchlist</a>
                 <a href="{{ url_for('favorites') }}" class="btn btn-sm btn-outline-primary me-2">Favorites</a>
+                <a href="{{ url_for('alerts') }}" class="btn btn-sm btn-outline-primary me-2">Alerts</a>
                 <a href="{{ url_for('export_history') }}" class="btn btn-sm btn-outline-secondary me-2">Export History</a>
                 <a href="{{ url_for('settings') }}" class="btn btn-sm btn-outline-secondary me-2">Settings</a>
                 <a href="{{ url_for('logout') }}" class="btn btn-sm btn-danger">Logout</a>


### PR DESCRIPTION
## Summary
- create a page to list saved alerts
- add routes for viewing and clearing alerts
- link to Alerts page from the navbar
- document the new feature in the README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685a44b51348832688024ca5e04d49a9