### PR TITLE
Add interest calculator tab

### DIFF
--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -30,6 +30,8 @@ def index():
     earnings_growth = forward_pe = price_to_sales = None
     error_message = alert_message = None
     history_dates = history_prices = []
+    interest_amount = interest_rate = interest_result = None
+    active_tab = 'pe'
 
     if request.method == 'GET':
         symbol = request.args.get('ticker', '').upper() or symbol
@@ -45,9 +47,19 @@ def index():
     else:
         history = session.get('history', [])
 
-    if request.method == 'POST' or symbol:
-        if request.method == 'POST':
+    if request.method == 'POST':
+        if request.form.get('calc_type') == 'interest':
+            active_tab = 'interest'
+            try:
+                interest_amount = float(request.form.get('amount', 0))
+                interest_rate = float(request.form.get('rate', 0))
+                interest_result = round(interest_amount * interest_rate / 100, 2)
+            except ValueError:
+                error_message = 'Invalid amount or interest rate.'
+        else:
             symbol = request.form['ticker'].upper()
+
+    if (request.method == 'POST' and request.form.get('calc_type') != 'interest') or symbol:
         try:
             (
                 company_name,
@@ -161,6 +173,10 @@ def index():
         history_dates=history_dates,
         history_prices=history_prices,
         history=history,
+        interest_amount=interest_amount,
+        interest_rate=interest_rate,
+        interest_result=interest_result,
+        active_tab=active_tab,
     )
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>P/E Ratio Calculator</title>
+    <title>Finance Tools</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
@@ -30,7 +30,17 @@
             <div class="col-md-6 col-sm-12">
                 <div class="card shadow-sm">
                     <div class="card-body">
-                        <h3 class="card-title text-center mb-4">P/E Ratio Calculator</h3>
+                        <h3 class="card-title text-center mb-4">Finance Tools</h3>
+                        <ul class="nav nav-tabs mb-3" id="calcTabs" role="tablist">
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link {% if active_tab != 'interest' %}active{% endif %}" id="pe-tab" data-bs-toggle="tab" data-bs-target="#pe" type="button" role="tab" aria-controls="pe" aria-selected="{{ 'true' if active_tab != 'interest' else 'false' }}">P/E Ratio</button>
+                            </li>
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link {% if active_tab == 'interest' %}active{% endif %}" id="interest-tab" data-bs-toggle="tab" data-bs-target="#interest" type="button" role="tab" aria-controls="interest" aria-selected="{{ 'true' if active_tab == 'interest' else 'false' }}">Interest</button>
+                            </li>
+                        </ul>
+                        <div class="tab-content">
+                            <div class="tab-pane fade {% if active_tab != 'interest' %}show active{% endif %}" id="pe" role="tabpanel" aria-labelledby="pe-tab">
                         <form method="GET">
                             <div class="mb-3">
                                 <label for="ticker" class="form-label">Ticker Symbol:</label>
@@ -163,11 +173,34 @@
                                 <a href="{{ url_for('download', symbol=symbol, format='pdf') }}" class="btn btn-secondary">Download PDF</a>
                             </div>
                         {% endif %}
+                            </div>
+                            <div class="tab-pane fade {% if active_tab == 'interest' %}show active{% endif %}" id="interest" role="tabpanel" aria-labelledby="interest-tab">
+                                <form method="POST">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <input type="hidden" name="calc_type" value="interest">
+                                    <div class="mb-3">
+                                        <label for="amount" class="form-label">Amount</label>
+                                        <input type="number" step="any" id="amount" name="amount" value="{{ interest_amount }}" class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="rate" class="form-label">Interest Rate (%)</label>
+                                        <input type="number" step="any" id="rate" name="rate" value="{{ interest_rate }}" class="form-control" required>
+                                    </div>
+                                    <div class="d-grid">
+                                        <button type="submit" class="btn btn-primary">Calculate</button>
+                                    </div>
+                                </form>
+                                {% if interest_result is not none %}
+                                    <p class="mt-3"><strong>Interest Earned:</strong> {{ interest_result }}</p>
+                                {% endif %}
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', function() {


### PR DESCRIPTION
## Summary
- expand `index` route with interest calculation logic
- add active tab tracking and pass interest values to template
- convert home page into tabbed interface with a new Interest tab
- load Bootstrap JS for tab functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd86083a083269308e900b275a7c6