### PR TITLE
Fix missing templates

### DIFF
--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -8,7 +8,11 @@ from .tasks import start_scheduler
 
 
 def create_app():
-    app = Flask(__name__)
+    app = Flask(
+        __name__,
+        template_folder="../templates",
+        static_folder="../static",
+    )
 
     app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'change_this_secret')
 


### PR DESCRIPTION
## Summary
- configure Flask to use correct template and static directories

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bdefc3ed88326a9c0f9728b17f7f6