### PR TITLE
Add loan calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Alongside the standard P/E ratio the app now fetches and displays:
 
 These extra metrics appear on the main page and in exported CSV/PDF files.
 
+## Finance Calculators
+
+The main page also hosts several quick calculators:
+
+* Simple interest
+* Compound interest
+* **Loan/Mortgage payment** – computes monthly payment, total interest and shows a full amortization schedule.
+
 ## Scheduled Alerts
 
 Alert emails are sent on a schedule using **APScheduler**. Each user can

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,6 +41,9 @@
                             <li class="nav-item" role="presentation">
                                 <button class="nav-link {% if active_tab == 'compound' %}active{% endif %}" id="compound-tab" data-bs-toggle="tab" data-bs-target="#compound" type="button" role="tab" aria-controls="compound" aria-selected="{{ 'true' if active_tab == 'compound' else 'false' }}">Compound Interest</button>
                             </li>
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link {% if active_tab == 'loan' %}active{% endif %}" id="loan-tab" data-bs-toggle="tab" data-bs-target="#loan" type="button" role="tab" aria-controls="loan" aria-selected="{{ 'true' if active_tab == 'loan' else 'false' }}">Loan/Mortgage</button>
+                            </li>
                         </ul>
                         <div class="tab-content">
                             <div class="tab-pane fade {% if active_tab == 'pe' %}show active{% endif %}" id="pe" role="tabpanel" aria-labelledby="pe-tab">
@@ -223,6 +226,55 @@
                                 </form>
                                 {% if comp_result is not none %}
                                     <p class="mt-3"><strong>Future Value:</strong> {{ comp_result }}</p>
+                                {% endif %}
+                            </div>
+                            <div class="tab-pane fade {% if active_tab == 'loan' %}show active{% endif %}" id="loan" role="tabpanel" aria-labelledby="loan-tab">
+                                <form method="POST">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <input type="hidden" name="calc_type" value="loan">
+                                    <div class="mb-3">
+                                        <label for="loan_amount" class="form-label">Loan Amount</label>
+                                        <input type="number" step="any" id="loan_amount" name="loan_amount" value="{{ loan_amount }}" class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="loan_rate" class="form-label">Annual Interest Rate (%)</label>
+                                        <input type="number" step="any" id="loan_rate" name="loan_rate" value="{{ loan_rate }}" class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="loan_years" class="form-label">Term (Years)</label>
+                                        <input type="number" step="any" id="loan_years" name="loan_years" value="{{ loan_years }}" class="form-control" required>
+                                    </div>
+                                    <div class="d-grid">
+                                        <button type="submit" class="btn btn-primary">Calculate</button>
+                                    </div>
+                                </form>
+                                {% if loan_result %}
+                                    <p class="mt-3"><strong>Monthly Payment:</strong> {{ loan_result.monthly_payment }}</p>
+                                    <p><strong>Total Interest:</strong> {{ loan_result.total_interest }}</p>
+                                    <div class="table-responsive mt-3">
+                                        <table class="table table-sm">
+                                            <thead>
+                                                <tr>
+                                                    <th>Month</th>
+                                                    <th>Payment</th>
+                                                    <th>Interest</th>
+                                                    <th>Principal</th>
+                                                    <th>Balance</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {% for row in loan_result.schedule %}
+                                                <tr>
+                                                    <td>{{ row.month }}</td>
+                                                    <td>{{ row.payment }}</td>
+                                                    <td>{{ row.interest }}</td>
+                                                    <td>{{ row.principal }}</td>
+                                                    <td>{{ row.balance }}</td>
+                                                </tr>
+                                                {% endfor %}
+                                            </tbody>
+                                        </table>
+                                    </div>
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- add loan calculator logic and state handling
- expose loan calculator in the UI
- document the new finance calculator in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685be300bac08326957a4cd1690649e4