### PR TITLE
Fix clear history link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -66,7 +66,7 @@
                                         <li class="list-group-item">{{ item }}</li>
                                     {% endfor %}
                                     </ul>
-                                    <a href="{{ url_for('clear_history') }}" class="btn btn-sm btn-danger mt-2">Clear History</a>
+                                    <a href="{{ url_for('main.clear_history') }}" class="btn btn-sm btn-danger mt-2">Clear History</a>
                                 </div>
                             {% endif %}
 


### PR DESCRIPTION
## Summary
- fix 404 by updating `url_for` in index template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be6f928b48326b99d1aecef1bc206