### PR TITLE
Fix download route links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -176,8 +176,8 @@
                                 </script>
                             {% endif %}
                             <div class="mt-3">
-                                <a href="{{ url_for('download', symbol=symbol, format='csv') }}" class="btn btn-secondary me-2">Download CSV</a>
-                                <a href="{{ url_for('download', symbol=symbol, format='pdf') }}" class="btn btn-secondary">Download PDF</a>
+                                <a href="{{ url_for('main.download', symbol=symbol, format='csv') }}" class="btn btn-secondary me-2">Download CSV</a>
+                                <a href="{{ url_for('main.download', symbol=symbol, format='pdf') }}" class="btn btn-secondary">Download PDF</a>
                             </div>
                         {% endif %}
                             </div>


### PR DESCRIPTION
## Summary
- fix the `url_for` references for the download endpoint to use the `main` blueprint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685be81a59dc832690cf37c1c48a5fc0