### PR TITLE
Add portfolio tracking

### DIFF
--- a/stockapp/models.py
+++ b/stockapp/models.py
@@ -36,3 +36,10 @@ class History(db.Model):
     symbol = db.Column(db.String(10))
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+
+class PortfolioItem(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    symbol = db.Column(db.String(10), nullable=False)
+    quantity = db.Column(db.Float, nullable=False)
+    price_paid = db.Column(db.Float, nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,7 @@
                 <span class="navbar-text me-2">Logged in as {{ current_user.username }}</span>
                 <a href="{{ url_for('watch.watchlist') }}" class="btn btn-sm btn-outline-primary me-2">Watchlist</a>
                 <a href="{{ url_for('watch.favorites') }}" class="btn btn-sm btn-outline-primary me-2">Favorites</a>
+                <a href="{{ url_for('watch.portfolio') }}" class="btn btn-sm btn-outline-primary me-2">Portfolio</a>
                 <a href="{{ url_for('watch.alerts') }}" class="btn btn-sm btn-outline-primary me-2">Alerts</a>
                 <a href="{{ url_for('watch.export_history') }}" class="btn btn-sm btn-outline-secondary me-2">Export History</a>
                 <a href="{{ url_for('watch.settings') }}" class="btn btn-sm btn-outline-secondary me-2">Settings</a>
@@ -138,6 +139,7 @@
                             {% if current_user.is_authenticated and symbol %}
                                 <a href="{{ url_for('watch.add_watchlist', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Watchlist</a>
                                 <a href="{{ url_for('watch.add_favorite', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Favorites</a>
+                                <a href="{{ url_for('watch.portfolio') }}?symbol={{ symbol }}" class="btn btn-sm btn-outline-primary mb-2">Add to Portfolio</a>
                             {% endif %}
 
                             {% if history_prices %}

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Portfolio</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h3 class="mb-4">Portfolio</h3>
+        <form method="POST" class="mb-3">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="row g-2">
+                <div class="col-md-3 col-sm-6">
+                    <input type="text" name="symbol" value="{{ symbol }}" class="form-control" placeholder="Ticker" required>
+                </div>
+                <div class="col-md-3 col-sm-6">
+                    <input type="number" step="any" name="quantity" class="form-control" placeholder="Quantity" required>
+                </div>
+                <div class="col-md-3 col-sm-6">
+                    <input type="number" step="any" name="price_paid" class="form-control" placeholder="Purchase Price" required>
+                </div>
+                <div class="col-md-3 col-sm-6 d-grid">
+                    <button class="btn btn-primary" type="submit">Add</button>
+                </div>
+            </div>
+        </form>
+        {% if items %}
+        <div class="table-responsive">
+            <table class="table table-sm table-bordered">
+                <thead>
+                    <tr>
+                        <th>Symbol</th>
+                        <th>Qty</th>
+                        <th>Price Paid</th>
+                        <th>Current Price</th>
+                        <th>Value</th>
+                        <th>P/L</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in items %}
+                    <tr>
+                        <form method="POST">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <input type="hidden" name="item_id" value="{{ row.item.id }}">
+                            <td>{{ row.item.symbol }}</td>
+                            <td><input type="number" step="any" name="quantity" value="{{ row.item.quantity }}" class="form-control form-control-sm"></td>
+                            <td><input type="number" step="any" name="price_paid" value="{{ row.item.price_paid }}" class="form-control form-control-sm"></td>
+                            <td>{{ row.current_price or 'N/A' }}</td>
+                            <td>{{ row.value or 'N/A' }}</td>
+                            <td>{{ row.profit_loss or 'N/A' }}</td>
+                            <td>
+                                <div class="btn-group btn-group-sm">
+                                    <button class="btn btn-primary" type="submit">Update</button>
+                                    <a href="{{ url_for('watch.delete_portfolio_item', item_id=row.item.id) }}" class="btn btn-danger">Delete</a>
+                                </div>
+                            </td>
+                        </form>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p>No portfolio items.</p>
+        {% endif %}
+        <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+    </div>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', function() {
+                navigator.serviceWorker.register('/service-worker.js');
+            });
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `PortfolioItem` model for storing portfolio holdings
- create portfolio management routes for adding, updating, and deleting holdings
- add Portfolio tab in navigation and a full portfolio template
- allow quick link from stock lookup to pre-fill portfolio form

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685be9bae99c8326af74391bbc4a3858