### PR TITLE
Add default login user

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ The codebase is organized as a Flask package named `stockapp`. The main `app.py`
 python app.py
 ```
 
+### Default Login
+
+On startup the app creates a verified user if it doesn't already exist. The
+default credentials are:
+
+* Username: `testuser`
+* Password: `testpass`
+
+You can override these by setting the `DEFAULT_USERNAME` and `DEFAULT_PASSWORD`
+environment variables before running the app.
+
 ## Account Verification and Password Reset
 
 After signing up the app sends a verification email containing a link to

--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -1,6 +1,8 @@
 import os
 from flask import Flask
+from werkzeug.security import generate_password_hash
 from .extensions import db, login_manager, csrf
+from .models import User
 from .auth import auth_bp
 from .main import main_bp
 from .watchlists import watch_bp
@@ -43,6 +45,19 @@ def create_app():
 
     with app.app_context():
         db.create_all()
+
+        # Create a default user for testing if credentials provided
+        default_user = os.environ.get('DEFAULT_USERNAME', 'testuser')
+        default_pass = os.environ.get('DEFAULT_PASSWORD', 'testpass')
+        if default_user and default_pass:
+            if not User.query.filter_by(username=default_user).first():
+                user = User(
+                    username=default_user,
+                    password_hash=generate_password_hash(default_pass),
+                    is_verified=True,
+                )
+                db.session.add(user)
+                db.session.commit()
 
     start_scheduler()
     return app


### PR DESCRIPTION
## Summary
- create a default user on startup if one doesn't exist
- document the default credentials in the README

## Testing
- `python -m py_compile stockapp/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_685bec52af8c8326a6e3e2a3647712a3