### PR TITLE
Add CSV import/export for portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Alongside the standard P/E ratio the app now fetches and displays:
 
 These extra metrics appear on the main page and in exported CSV/PDF files.
 
+## Portfolio CSV Import/Export
+
+Within the Portfolio page you can now export all holdings to a CSV file or
+import a file to quickly populate your portfolio. The CSV format uses the
+columns `Symbol`, `Quantity` and `Price Paid`.
+
 ## Finance Calculators
 
 The main page also hosts several quick calculators:

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -27,6 +27,14 @@
                 </div>
             </div>
         </form>
+        <div class="mb-3">
+            <a href="{{ url_for('watch.export_portfolio') }}" class="btn btn-outline-secondary btn-sm">Export CSV</a>
+            <form method="POST" enctype="multipart/form-data" class="d-inline-block ms-2">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="file" name="file" accept=".csv" required class="form-control form-control-sm d-inline-block" style="width:auto; display:inline-block;">
+                <button class="btn btn-outline-primary btn-sm" type="submit">Import CSV</button>
+            </form>
+        </div>
         {% if items %}
         <div class="table-responsive">
             <table class="table table-sm table-bordered">


### PR DESCRIPTION
## Summary
- add `export_portfolio` route and CSV export logic
- support CSV import on the Portfolio page
- expose import/export buttons in portfolio template
- document portfolio CSV options in README

## Testing
- `pytest -q`
- `python -m py_compile \
  `git ls-files '*.py'`

------
https://chatgpt.com/codex/tasks/task_e_685beeb2996083268faaa02589a84e94