### PR TITLE
Add total P/L row in portfolio

### DIFF
--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -70,6 +70,14 @@
                         </form>
                     </tr>
                     {% endfor %}
+                    {% if totals %}
+                    <tr class="table-secondary fw-bold">
+                        <td colspan="4" class="text-end">Totals</td>
+                        <td>{{ totals.value }}</td>
+                        <td>{{ totals.profit_loss }}</td>
+                        <td></td>
+                    </tr>
+                    {% endif %}
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
## Summary
- calculate total value and profit/loss for portfolio items
- show totals row on portfolio table

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf0dd4aa48326bd1a05841fe1b26d