### PR TITLE
Add PEG ratio metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ threshold is provided the default of 30 is used.
 Alongside the standard P/E ratio the app now fetches and displays:
 
 * **Forward P/E** – estimated using the latest EPS growth data.
+* **PEG ratio** – P/E divided by the earnings growth rate.
 * **Price-to-Sales (P/S) ratio** – retrieved from Financial Modeling Prep.
 
 These extra metrics appear on the main page and in exported CSV/PDF files.

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -28,6 +28,7 @@ def index():
     sector = industry = exchange = currency = debt_to_equity = None
     pb_ratio = roe = roa = profit_margin = analyst_rating = dividend_yield = None
     earnings_growth = forward_pe = price_to_sales = None
+    peg_ratio = None
     error_message = alert_message = None
     history_dates = history_prices = []
     interest_amount = interest_rate = interest_result = None
@@ -141,6 +142,16 @@ def index():
             if price is not None and eps:
                 pe_ratio_val = round(price / eps, 2)
                 pe_ratio = format_decimal(pe_ratio_val, locale=get_locale())
+                peg_ratio_val = None
+                if earnings_growth not in (None, 0):
+                    try:
+                        growth_pct = float(earnings_growth)
+                        if growth_pct != 0:
+                            peg_ratio_val = pe_ratio_val / (growth_pct * 100)
+                    except (TypeError, ValueError):
+                        peg_ratio_val = None
+                if peg_ratio_val is not None:
+                    peg_ratio = format_decimal(round(peg_ratio_val, 2), locale=get_locale())
                 if pe_ratio_val < 15:
                     valuation = 'Undervalued?'
                 elif pe_ratio_val > 25:
@@ -203,6 +214,7 @@ def index():
         price=price,
         eps=eps,
         pe_ratio=pe_ratio,
+        peg_ratio=peg_ratio,
         valuation=valuation,
         company_name=company_name,
         logo_url=logo_url,
@@ -283,6 +295,14 @@ def download():
 
     if price is not None and eps:
         pe_ratio_val = round(price / eps, 2)
+        peg_ratio_val = None
+        if earnings_growth not in (None, 0):
+            try:
+                growth_pct = float(earnings_growth)
+                if growth_pct != 0:
+                    peg_ratio_val = pe_ratio_val / (growth_pct * 100)
+            except (TypeError, ValueError):
+                peg_ratio_val = None
         if pe_ratio_val < 15:
             valuation = 'Undervalued?'
         elif pe_ratio_val > 25:
@@ -290,8 +310,13 @@ def download():
         else:
             valuation = 'Fairly Valued'
         pe_ratio = format_decimal(pe_ratio_val, locale=get_locale())
+        peg_ratio = (
+            format_decimal(round(peg_ratio_val, 2), locale=get_locale())
+            if peg_ratio_val is not None
+            else 'N/A'
+        )
     else:
-        pe_ratio = valuation = 'N/A'
+        pe_ratio = valuation = peg_ratio = 'N/A'
 
     if debt_to_equity is not None:
         debt_to_equity = format_decimal(round(debt_to_equity, 2), locale=get_locale())
@@ -326,6 +351,7 @@ def download():
             'Price',
             'EPS',
             'P/E Ratio',
+            'PEG Ratio',
             'Valuation',
             'Market Cap',
             'Debt/Equity',
@@ -349,6 +375,7 @@ def download():
             price,
             eps,
             pe_ratio,
+            peg_ratio,
             valuation,
             market_cap,
             debt_to_equity,
@@ -380,6 +407,7 @@ def download():
             ('Price', price),
             ('EPS', eps),
             ('P/E Ratio', pe_ratio),
+            ('PEG Ratio', peg_ratio),
             ('Valuation', valuation),
             ('Market Cap', market_cap),
             ('Debt/Equity', debt_to_equity),

--- a/templates/index.html
+++ b/templates/index.html
@@ -48,7 +48,7 @@
                         </ul>
                         <div class="tab-content">
                             <div class="tab-pane fade {% if active_tab == 'pe' %}show active{% endif %}" id="pe" role="tabpanel" aria-labelledby="pe-tab">
-                                <p class="small text-muted">Adding a PEG ratio (Price/Earnings-to-Growth) calculator would extend the metrics already provided in the app. The README notes that the app currently shows P/E, forward P/E, and price-to-sales ratios. Since get_stock_data already fetches earnings growth data in stockapp/utils.py, computing the PEG ratio would involve dividing the P/E ratio by the earnings growth percentage. This would help users see how a company&rsquo;s valuation compares to its expected growth.</p>
+                                <p class="small text-muted">The app also displays the PEG ratio (Price/Earnings-to-Growth), calculated by dividing the P/E ratio by the earnings growth rate. This highlights valuation relative to growth.</p>
                         <form method="GET">
                             <div class="mb-3">
                                 <label for="ticker" class="form-label">Ticker Symbol:</label>
@@ -132,6 +132,9 @@
                             {% endif %}
                             {% if forward_pe is not none %}
                                 <p><strong>Forward P/E:</strong> {{ forward_pe }}</p>
+                            {% endif %}
+                            {% if peg_ratio is not none %}
+                                <p><strong>PEG Ratio:</strong> {{ peg_ratio }}</p>
                             {% endif %}
                             {% if price_to_sales is not none %}
                                 <p><strong>P/S Ratio:</strong> {{ price_to_sales }}</p>


### PR DESCRIPTION
## Summary
- compute PEG ratio in main routes
- display PEG ratio on main page and in downloads
- document PEG ratio as an additional metric

## Testing
- `python -m py_compile stockapp/main/routes.py stockapp/utils.py`
- `find stockapp -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_685c98aa185883269aa9dda8bdf3f3f5