### PR TITLE
Add Enterprise Value/EBITDA metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Alongside the standard P/E ratio the app now fetches and displays:
 * **Forward P/E** – estimated using the latest EPS growth data.
 * **PEG ratio** – P/E divided by the earnings growth rate.
 * **Price-to-Sales (P/S) ratio** – retrieved from Financial Modeling Prep.
+* **Enterprise Value/EBITDA** – helps assess valuation considering both debt and equity financing.
 
 These extra metrics appear on the main page and in exported CSV/PDF files.
 

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -27,7 +27,7 @@ def index():
     price = eps = pe_ratio = valuation = company_name = logo_url = market_cap = None
     sector = industry = exchange = currency = debt_to_equity = None
     pb_ratio = roe = roa = profit_margin = analyst_rating = dividend_yield = None
-    earnings_growth = forward_pe = price_to_sales = None
+    earnings_growth = forward_pe = price_to_sales = ev_to_ebitda = None
     peg_ratio = None
     error_message = alert_message = None
     history_dates = history_prices = []
@@ -135,6 +135,7 @@ def index():
                 earnings_growth,
                 forward_pe,
                 price_to_sales,
+                ev_to_ebitda,
             ) = get_stock_data(symbol)
 
             history_dates, history_prices = get_historical_prices(symbol, days=90)
@@ -188,6 +189,8 @@ def index():
                 forward_pe = format_decimal(round(forward_pe, 2), locale=get_locale())
             if price_to_sales is not None:
                 price_to_sales = format_decimal(round(price_to_sales, 2), locale=get_locale())
+            if ev_to_ebitda is not None:
+                ev_to_ebitda = format_decimal(round(ev_to_ebitda, 2), locale=get_locale())
             if price is not None:
                 price = format_currency(price, currency, locale=get_locale())
             if eps is not None:
@@ -233,6 +236,7 @@ def index():
         earnings_growth=earnings_growth,
         forward_pe=forward_pe,
         price_to_sales=price_to_sales,
+        ev_to_ebitda=ev_to_ebitda,
         error_message=error_message,
         alert_message=alert_message,
         history_dates=history_dates,
@@ -291,6 +295,7 @@ def download():
         earnings_growth,
         forward_pe,
         price_to_sales,
+        ev_to_ebitda,
     ) = get_stock_data(symbol)
 
     if price is not None and eps:
@@ -336,6 +341,8 @@ def download():
         forward_pe = format_decimal(round(forward_pe, 2), locale=get_locale())
     if price_to_sales is not None:
         price_to_sales = format_decimal(round(price_to_sales, 2), locale=get_locale())
+    if ev_to_ebitda is not None:
+        ev_to_ebitda = format_decimal(round(ev_to_ebitda, 2), locale=get_locale())
 
     if price is not None:
         price = format_currency(price, currency, locale=get_locale())
@@ -364,6 +371,7 @@ def download():
             'Earnings Growth %',
             'Forward P/E',
             'P/S Ratio',
+            'EV/EBITDA',
             'Sector',
             'Industry',
             'Exchange',
@@ -388,6 +396,7 @@ def download():
             earnings_growth,
             forward_pe,
             price_to_sales,
+            ev_to_ebitda,
             sector,
             industry,
             exchange,
@@ -420,6 +429,7 @@ def download():
             ('Earnings Growth %', earnings_growth),
             ('Forward P/E', forward_pe),
             ('P/S Ratio', price_to_sales),
+            ('EV/EBITDA', ev_to_ebitda),
             ('Sector', sector),
             ('Industry', industry),
             ('Exchange', exchange),

--- a/stockapp/utils.py
+++ b/stockapp/utils.py
@@ -85,7 +85,7 @@ def get_stock_data(symbol):
         quote_response = requests.get(quote_url, timeout=10)
         quote_data = quote_response.json()
         if not isinstance(quote_data, list) or len(quote_data) == 0:
-            return (None,) * 19
+            return (None,) * 20
         quote = quote_data[0]
 
         profile_response = requests.get(profile_url, timeout=10)
@@ -95,7 +95,7 @@ def get_stock_data(symbol):
         ratio_response = requests.get(ratios_url, timeout=10)
         ratio_data = ratio_response.json()
         debt_to_equity = pb_ratio = roe = roa = profit_margin = dividend_yield = None
-        price_to_sales = None
+        price_to_sales = ev_to_ebitda = None
         if isinstance(ratio_data, list) and len(ratio_data) > 0:
             r = ratio_data[0]
             debt_to_equity = r.get('debtEquityRatioTTM')
@@ -105,6 +105,17 @@ def get_stock_data(symbol):
             profit_margin = r.get('netProfitMarginTTM')
             dividend_yield = r.get('dividendYielTTM') or r.get('dividendYieldTTM')
             price_to_sales = r.get('priceToSalesRatioTTM')
+
+        metrics_url = f'https://financialmodelingprep.com/api/v3/key-metrics-ttm/{symbol}?apikey={API_KEY}'
+        metrics_response = requests.get(metrics_url, timeout=10)
+        metrics_data = metrics_response.json()
+        if isinstance(metrics_data, list) and len(metrics_data) > 0:
+            m = metrics_data[0]
+            ev_to_ebitda = (
+                m.get('evToEbitdaTTM')
+                or m.get('evToEbitda')
+                or m.get('enterpriseValueOverEBITDA')
+            )
 
         rating_response = requests.get(rating_url, timeout=10)
         rating_data = rating_response.json()
@@ -162,7 +173,8 @@ def get_stock_data(symbol):
             earnings_growth,
             forward_pe,
             price_to_sales,
+            ev_to_ebitda,
         )
     except Exception as e:
         print(f'API error: {e}')
-        return (None,) * 19
+        return (None,) * 20

--- a/templates/index.html
+++ b/templates/index.html
@@ -139,6 +139,9 @@
                             {% if price_to_sales is not none %}
                                 <p><strong>P/S Ratio:</strong> {{ price_to_sales }}</p>
                             {% endif %}
+                            {% if ev_to_ebitda is not none %}
+                                <p><strong>EV/EBITDA:</strong> {{ ev_to_ebitda }}</p>
+                            {% endif %}
                             {% if current_user.is_authenticated and symbol %}
                                 <a href="{{ url_for('watch.add_watchlist', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Watchlist</a>
                                 <a href="{{ url_for('watch.add_favorite', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Favorites</a>


### PR DESCRIPTION
## Summary
- fetch EV/EBITDA from FMP key metrics
- display EV/EBITDA on index page
- include EV/EBITDA in CSV/PDF downloads
- document new metric in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c9bca3d9083269739044c4f56f831