### PR TITLE
Add P/FCF ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Alongside the standard P/E ratio the app now fetches and displays:
 * **PEG ratio** – P/E divided by the earnings growth rate.
 * **Price-to-Sales (P/S) ratio** – retrieved from Financial Modeling Prep.
 * **Enterprise Value/EBITDA** – helps assess valuation considering both debt and equity financing.
+* **Price-to-Free-Cash-Flow (P/FCF) ratio** – calculates valuation using free cash flow per share.
 
 These extra metrics appear on the main page and in exported CSV/PDF files.
 

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -27,7 +27,7 @@ def index():
     price = eps = pe_ratio = valuation = company_name = logo_url = market_cap = None
     sector = industry = exchange = currency = debt_to_equity = None
     pb_ratio = roe = roa = profit_margin = analyst_rating = dividend_yield = None
-    earnings_growth = forward_pe = price_to_sales = ev_to_ebitda = None
+    earnings_growth = forward_pe = price_to_sales = ev_to_ebitda = price_to_fcf = None
     peg_ratio = None
     error_message = alert_message = None
     history_dates = history_prices = []
@@ -136,6 +136,7 @@ def index():
                 forward_pe,
                 price_to_sales,
                 ev_to_ebitda,
+                price_to_fcf,
             ) = get_stock_data(symbol)
 
             history_dates, history_prices = get_historical_prices(symbol, days=90)
@@ -191,6 +192,8 @@ def index():
                 price_to_sales = format_decimal(round(price_to_sales, 2), locale=get_locale())
             if ev_to_ebitda is not None:
                 ev_to_ebitda = format_decimal(round(ev_to_ebitda, 2), locale=get_locale())
+            if price_to_fcf is not None:
+                price_to_fcf = format_decimal(round(price_to_fcf, 2), locale=get_locale())
             if price is not None:
                 price = format_currency(price, currency, locale=get_locale())
             if eps is not None:
@@ -237,6 +240,7 @@ def index():
         forward_pe=forward_pe,
         price_to_sales=price_to_sales,
         ev_to_ebitda=ev_to_ebitda,
+        price_to_fcf=price_to_fcf,
         error_message=error_message,
         alert_message=alert_message,
         history_dates=history_dates,
@@ -296,6 +300,7 @@ def download():
         forward_pe,
         price_to_sales,
         ev_to_ebitda,
+        price_to_fcf,
     ) = get_stock_data(symbol)
 
     if price is not None and eps:
@@ -343,6 +348,8 @@ def download():
         price_to_sales = format_decimal(round(price_to_sales, 2), locale=get_locale())
     if ev_to_ebitda is not None:
         ev_to_ebitda = format_decimal(round(ev_to_ebitda, 2), locale=get_locale())
+    if price_to_fcf is not None:
+        price_to_fcf = format_decimal(round(price_to_fcf, 2), locale=get_locale())
 
     if price is not None:
         price = format_currency(price, currency, locale=get_locale())
@@ -372,6 +379,7 @@ def download():
             'Forward P/E',
             'P/S Ratio',
             'EV/EBITDA',
+            'P/FCF Ratio',
             'Sector',
             'Industry',
             'Exchange',
@@ -397,6 +405,7 @@ def download():
             forward_pe,
             price_to_sales,
             ev_to_ebitda,
+            price_to_fcf,
             sector,
             industry,
             exchange,
@@ -430,6 +439,7 @@ def download():
             ('Forward P/E', forward_pe),
             ('P/S Ratio', price_to_sales),
             ('EV/EBITDA', ev_to_ebitda),
+            ('P/FCF Ratio', price_to_fcf),
             ('Sector', sector),
             ('Industry', industry),
             ('Exchange', exchange),

--- a/templates/index.html
+++ b/templates/index.html
@@ -142,6 +142,9 @@
                             {% if ev_to_ebitda is not none %}
                                 <p><strong>EV/EBITDA:</strong> {{ ev_to_ebitda }}</p>
                             {% endif %}
+                            {% if price_to_fcf is not none %}
+                                <p><strong>P/FCF Ratio:</strong> {{ price_to_fcf }}</p>
+                            {% endif %}
                             {% if current_user.is_authenticated and symbol %}
                                 <a href="{{ url_for('watch.add_watchlist', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Watchlist</a>
                                 <a href="{{ url_for('watch.add_favorite', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Favorites</a>


### PR DESCRIPTION
## Summary
- fetch price-to-free-cash-flow ratio from API and compute when missing
- display P/FCF on the homepage and include it in exports
- document the new metric in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c9fc0aaa0832691bff65f90bcae5b