### PR TITLE
Add dividend payout ratio metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Alongside the standard P/E ratio the app now fetches and displays:
 * **Price-to-Sales (P/S) ratio** – retrieved from Financial Modeling Prep.
 * **Enterprise Value/EBITDA** – helps assess valuation considering both debt and equity financing.
 * **Price-to-Free-Cash-Flow (P/FCF) ratio** – calculates valuation using free cash flow per share.
+* **Dividend Payout Ratio** – shows what percentage of earnings are distributed as dividends.
 
 These extra metrics appear on the main page and in exported CSV/PDF files.
 

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -26,7 +26,7 @@ def index():
     symbol = ''
     price = eps = pe_ratio = valuation = company_name = logo_url = market_cap = None
     sector = industry = exchange = currency = debt_to_equity = None
-    pb_ratio = roe = roa = profit_margin = analyst_rating = dividend_yield = None
+    pb_ratio = roe = roa = profit_margin = analyst_rating = dividend_yield = payout_ratio = None
     earnings_growth = forward_pe = price_to_sales = ev_to_ebitda = price_to_fcf = None
     peg_ratio = None
     error_message = alert_message = None
@@ -132,6 +132,7 @@ def index():
                 profit_margin,
                 analyst_rating,
                 dividend_yield,
+                payout_ratio,
                 earnings_growth,
                 forward_pe,
                 price_to_sales,
@@ -184,6 +185,8 @@ def index():
                 profit_margin = format_decimal(round(profit_margin * 100, 2), locale=get_locale())
             if dividend_yield is not None:
                 dividend_yield = format_decimal(round(dividend_yield * 100, 2), locale=get_locale())
+            if payout_ratio is not None:
+                payout_ratio = format_decimal(round(payout_ratio * 100, 2), locale=get_locale())
             if earnings_growth is not None:
                 earnings_growth = format_decimal(round(earnings_growth * 100, 2), locale=get_locale())
             if forward_pe is not None:
@@ -236,6 +239,7 @@ def index():
         profit_margin=profit_margin,
         analyst_rating=analyst_rating,
         dividend_yield=dividend_yield,
+        payout_ratio=payout_ratio,
         earnings_growth=earnings_growth,
         forward_pe=forward_pe,
         price_to_sales=price_to_sales,
@@ -296,6 +300,7 @@ def download():
         profit_margin,
         analyst_rating,
         dividend_yield,
+        payout_ratio,
         earnings_growth,
         forward_pe,
         price_to_sales,
@@ -340,6 +345,8 @@ def download():
         profit_margin = format_decimal(round(profit_margin * 100, 2), locale=get_locale())
     if dividend_yield is not None:
         dividend_yield = format_decimal(round(dividend_yield * 100, 2), locale=get_locale())
+    if payout_ratio is not None:
+        payout_ratio = format_decimal(round(payout_ratio * 100, 2), locale=get_locale())
     if earnings_growth is not None:
         earnings_growth = format_decimal(round(earnings_growth * 100, 2), locale=get_locale())
     if forward_pe is not None:
@@ -375,6 +382,7 @@ def download():
             'Profit Margin %',
             'Analyst Rating',
             'Dividend Yield %',
+            'Dividend Payout Ratio %',
             'Earnings Growth %',
             'Forward P/E',
             'P/S Ratio',
@@ -401,6 +409,7 @@ def download():
             profit_margin,
             analyst_rating,
             dividend_yield,
+            payout_ratio,
             earnings_growth,
             forward_pe,
             price_to_sales,
@@ -435,6 +444,7 @@ def download():
             ('Profit Margin %', profit_margin),
             ('Analyst Rating', analyst_rating),
             ('Dividend Yield %', dividend_yield),
+            ('Dividend Payout Ratio %', payout_ratio),
             ('Earnings Growth %', earnings_growth),
             ('Forward P/E', forward_pe),
             ('P/S Ratio', price_to_sales),

--- a/stockapp/utils.py
+++ b/stockapp/utils.py
@@ -110,7 +110,7 @@ def _get_asx_stock_data(symbol):
         resp = requests.get(url, timeout=10)
         data = resp.json().get("quoteResponse", {}).get("result", [])
         if not data:
-            return (None,) * 21
+            return (None,) * 22
         info = data[0]
         name = info.get("longName") or info.get("shortName", "")
         price = info.get("regularMarketPrice")
@@ -139,10 +139,12 @@ def _get_asx_stock_data(symbol):
             None,
             None,
             None,
+            None,
+            None,
         )
     except Exception as e:
         print(f"ASX API error: {e}")
-        return (None,) * 21
+        return (None,) * 22
 
 
 def get_stock_data(symbol):
@@ -158,7 +160,7 @@ def get_stock_data(symbol):
         quote_response = requests.get(quote_url, timeout=10)
         quote_data = quote_response.json()
         if not isinstance(quote_data, list) or len(quote_data) == 0:
-            return (None,) * 21
+            return (None,) * 22
         quote = quote_data[0]
 
         profile_response = requests.get(profile_url, timeout=10)
@@ -167,7 +169,7 @@ def get_stock_data(symbol):
 
         ratio_response = requests.get(ratios_url, timeout=10)
         ratio_data = ratio_response.json()
-        debt_to_equity = pb_ratio = roe = roa = profit_margin = dividend_yield = None
+        debt_to_equity = pb_ratio = roe = roa = profit_margin = dividend_yield = payout_ratio = None
         price_to_sales = ev_to_ebitda = price_to_fcf = None
         if isinstance(ratio_data, list) and len(ratio_data) > 0:
             r = ratio_data[0]
@@ -177,6 +179,7 @@ def get_stock_data(symbol):
             roa = r.get('returnOnAssetsTTM')
             profit_margin = r.get('netProfitMarginTTM')
             dividend_yield = r.get('dividendYielTTM') or r.get('dividendYieldTTM')
+            payout_ratio = r.get('payoutRatioTTM') or r.get('payoutRatio')
             price_to_sales = r.get('priceToSalesRatioTTM')
             price_to_fcf = (
                 r.get('priceToFreeCashFlowRatioTTM')
@@ -257,6 +260,7 @@ def get_stock_data(symbol):
             profit_margin,
             analyst_rating,
             dividend_yield,
+            payout_ratio,
             earnings_growth,
             forward_pe,
             price_to_sales,
@@ -265,4 +269,4 @@ def get_stock_data(symbol):
         )
     except Exception as e:
         print(f'API error: {e}')
-        return (None,) * 21
+        return (None,) * 22

--- a/templates/index.html
+++ b/templates/index.html
@@ -127,6 +127,9 @@
                             {% if dividend_yield is not none %}
                                 <p><strong>Dividend Yield:</strong> {{ dividend_yield }}%</p>
                             {% endif %}
+                            {% if payout_ratio is not none %}
+                                <p><strong>Dividend Payout Ratio:</strong> {{ payout_ratio }}%</p>
+                            {% endif %}
                             {% if earnings_growth is not none %}
                                 <p><strong>Earnings Growth:</strong> {{ earnings_growth }}%</p>
                             {% endif %}


### PR DESCRIPTION
## Summary
- support Dividend Payout Ratio in utils data fetch
- show dividend payout info on the main page
- include payout ratio in CSV/PDF exports
- document new metric in README

## Testing
- `python -m py_compile stockapp/utils.py stockapp/main/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca2ad7dc8832685eb24bac5eeea54