### PR TITLE
Add current ratio metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Alongside the standard P/E ratio the app now fetches and displays:
 * **Enterprise Value/EBITDA** – helps assess valuation considering both debt and equity financing.
 * **Price-to-Free-Cash-Flow (P/FCF) ratio** – calculates valuation using free cash flow per share.
 * **Dividend Payout Ratio** – shows what percentage of earnings are distributed as dividends.
+* **Current Ratio** – current assets divided by current liabilities, indicating short-term liquidity.
 
 These extra metrics appear on the main page and in exported CSV/PDF files.
 

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -27,7 +27,7 @@ def index():
     price = eps = pe_ratio = valuation = company_name = logo_url = market_cap = None
     sector = industry = exchange = currency = debt_to_equity = None
     pb_ratio = roe = roa = profit_margin = analyst_rating = dividend_yield = payout_ratio = None
-    earnings_growth = forward_pe = price_to_sales = ev_to_ebitda = price_to_fcf = None
+    earnings_growth = forward_pe = price_to_sales = ev_to_ebitda = price_to_fcf = current_ratio = None
     peg_ratio = None
     error_message = alert_message = None
     history_dates = history_prices = []
@@ -138,6 +138,7 @@ def index():
                 price_to_sales,
                 ev_to_ebitda,
                 price_to_fcf,
+                current_ratio,
             ) = get_stock_data(symbol)
 
             history_dates, history_prices = get_historical_prices(symbol, days=90)
@@ -197,6 +198,8 @@ def index():
                 ev_to_ebitda = format_decimal(round(ev_to_ebitda, 2), locale=get_locale())
             if price_to_fcf is not None:
                 price_to_fcf = format_decimal(round(price_to_fcf, 2), locale=get_locale())
+            if current_ratio is not None:
+                current_ratio = format_decimal(round(current_ratio, 2), locale=get_locale())
             if price is not None:
                 price = format_currency(price, currency, locale=get_locale())
             if eps is not None:
@@ -245,6 +248,7 @@ def index():
         price_to_sales=price_to_sales,
         ev_to_ebitda=ev_to_ebitda,
         price_to_fcf=price_to_fcf,
+        current_ratio=current_ratio,
         error_message=error_message,
         alert_message=alert_message,
         history_dates=history_dates,
@@ -306,6 +310,7 @@ def download():
         price_to_sales,
         ev_to_ebitda,
         price_to_fcf,
+        current_ratio,
     ) = get_stock_data(symbol)
 
     if price is not None and eps:
@@ -357,6 +362,8 @@ def download():
         ev_to_ebitda = format_decimal(round(ev_to_ebitda, 2), locale=get_locale())
     if price_to_fcf is not None:
         price_to_fcf = format_decimal(round(price_to_fcf, 2), locale=get_locale())
+    if current_ratio is not None:
+        current_ratio = format_decimal(round(current_ratio, 2), locale=get_locale())
 
     if price is not None:
         price = format_currency(price, currency, locale=get_locale())
@@ -388,6 +395,7 @@ def download():
             'P/S Ratio',
             'EV/EBITDA',
             'P/FCF Ratio',
+            'Current Ratio',
             'Sector',
             'Industry',
             'Exchange',
@@ -415,6 +423,7 @@ def download():
             price_to_sales,
             ev_to_ebitda,
             price_to_fcf,
+            current_ratio,
             sector,
             industry,
             exchange,
@@ -450,6 +459,7 @@ def download():
             ('P/S Ratio', price_to_sales),
             ('EV/EBITDA', ev_to_ebitda),
             ('P/FCF Ratio', price_to_fcf),
+            ('Current Ratio', current_ratio),
             ('Sector', sector),
             ('Industry', industry),
             ('Exchange', exchange),

--- a/stockapp/utils.py
+++ b/stockapp/utils.py
@@ -141,10 +141,11 @@ def _get_asx_stock_data(symbol):
             None,
             None,
             None,
+            None,
         )
     except Exception as e:
         print(f"ASX API error: {e}")
-        return (None,) * 22
+        return (None,) * 23
 
 
 def get_stock_data(symbol):
@@ -170,7 +171,7 @@ def get_stock_data(symbol):
         ratio_response = requests.get(ratios_url, timeout=10)
         ratio_data = ratio_response.json()
         debt_to_equity = pb_ratio = roe = roa = profit_margin = dividend_yield = payout_ratio = None
-        price_to_sales = ev_to_ebitda = price_to_fcf = None
+        price_to_sales = ev_to_ebitda = price_to_fcf = current_ratio = None
         if isinstance(ratio_data, list) and len(ratio_data) > 0:
             r = ratio_data[0]
             debt_to_equity = r.get('debtEquityRatioTTM')
@@ -187,6 +188,7 @@ def get_stock_data(symbol):
                 or r.get('priceFreeCashFlowRatioTTM')
                 or r.get('priceCashFlowRatioTTM')
             )
+            current_ratio = r.get('currentRatioTTM')
 
         metrics_url = f'https://financialmodelingprep.com/api/v3/key-metrics-ttm/{symbol}?apikey={API_KEY}'
         metrics_response = requests.get(metrics_url, timeout=10)
@@ -266,7 +268,8 @@ def get_stock_data(symbol):
             price_to_sales,
             ev_to_ebitda,
             price_to_fcf,
+            current_ratio,
         )
     except Exception as e:
         print(f'API error: {e}')
-        return (None,) * 22
+        return (None,) * 23

--- a/templates/index.html
+++ b/templates/index.html
@@ -148,6 +148,9 @@
                             {% if price_to_fcf is not none %}
                                 <p><strong>P/FCF Ratio:</strong> {{ price_to_fcf }}</p>
                             {% endif %}
+                            {% if current_ratio is not none %}
+                                <p><strong>Current Ratio:</strong> {{ current_ratio }}</p>
+                            {% endif %}
                             {% if current_user.is_authenticated and symbol %}
                                 <a href="{{ url_for('watch.add_watchlist', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Watchlist</a>
                                 <a href="{{ url_for('watch.add_favorite', symbol=symbol) }}" class="btn btn-sm btn-outline-primary mb-2">Add to Favorites</a>


### PR DESCRIPTION
## Summary
- fetch `currentRatioTTM` from the Financial Modeling Prep API
- include Current Ratio in index results
- export Current Ratio to CSV/PDF downloads
- display Current Ratio on the main page
- document the new metric in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ca54f3ce48326b04579c93c4eb18e