### PR TITLE
Add MarketMinder brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stock Analysis App
+# MarketMinder
 
 This Flask application calculates P/E ratios and stores user data using SQLAlchemy. Authentication is handled via **Flask-Login**.
 

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "P/E Ratio Analyzer",
-  "short_name": "PE Ratio",
+  "name": "MarketMinder",
+  "short_name": "Minder",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -35,9 +35,12 @@ def create_app():
     csrf.init_app(app)
 
     @app.context_processor
-    def inject_csrf_token():
+    def inject_globals():
         from flask_wtf.csrf import generate_csrf
-        return dict(csrf_token=generate_csrf)
+        return {
+            'csrf_token': generate_csrf,
+            'app_name': 'MarketMinder'
+        }
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)

--- a/templates/alerts.html
+++ b/templates/alerts.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Alerts</title>
+    <title>{{ app_name }} - Alerts</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <h3 class="mb-4">Alert History</h3>
         {% if alerts %}

--- a/templates/favorites.html
+++ b/templates/favorites.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Favorites</title>
+    <title>{{ app_name }} - Favorites</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <h3 class="mb-4">Favorite Tickers</h3>
         <form method="POST" class="mb-3">

--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Forgot Password</title>
+    <title>{{ app_name }} - Forgot Password</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <div class="row justify-content-center">
             <div class="col-md-4 col-sm-12">

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,12 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Finance Tools</title>
+    <title>{{ app_name }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <nav class="navbar navbar-light bg-white shadow-sm">
         <div class="container">
             {% if current_user.is_authenticated %}
@@ -32,7 +37,7 @@
             <div class="col-md-6 col-sm-12">
                 <div class="card shadow-sm">
                     <div class="card-body">
-                        <h3 class="card-title text-center mb-4">Finance Tools</h3>
+                        <h3 class="card-title text-center mb-4">{{ app_name }}</h3>
                         <ul class="nav nav-tabs mb-3" id="calcTabs" role="tablist">
                             <li class="nav-item" role="presentation">
                                 <button class="nav-link {% if active_tab == 'pe' %}active{% endif %}" id="pe-tab" data-bs-toggle="tab" data-bs-target="#pe" type="button" role="tab" aria-controls="pe" aria-selected="{{ 'true' if active_tab == 'pe' else 'false' }}">P/E Ratio</button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Login</title>
+    <title>{{ app_name }} - Login</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <div class="row justify-content-center">
             <div class="col-md-4 col-sm-12">

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Portfolio</title>
+    <title>{{ app_name }} - Portfolio</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <h3 class="mb-4">Portfolio</h3>
         <form method="POST" class="mb-3">

--- a/templates/records.html
+++ b/templates/records.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Saved Records</title>
+    <title>{{ app_name }} - Saved Records</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <h3 class="mb-4">Saved Stock Records</h3>
         {% if records %}

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Reset Password</title>
+    <title>{{ app_name }} - Reset Password</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <div class="row justify-content-center">
             <div class="col-md-4 col-sm-12">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Alert Settings</title>
+    <title>{{ app_name }} - Alert Settings</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <h3 class="mb-4">Alert Settings</h3>
         <form method="POST" class="mb-3" style="max-width:300px;">

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Sign Up</title>
+    <title>{{ app_name }} - Sign Up</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <div class="row justify-content-center">
             <div class="col-md-4 col-sm-12">

--- a/templates/verify_email.html
+++ b/templates/verify_email.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Email Verification</title>
+    <title>{{ app_name }} - Email Verification</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <div class="row justify-content-center">
             <div class="col-md-6 col-sm-12">

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -3,11 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Watchlist</title>
+    <title>{{ app_name }} - Watchlist</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>
 <body class="bg-light">
+    <div class="bg-primary text-white text-center py-2 mb-3">
+        <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
+            <h1 class="h3 m-0">{{ app_name }}</h1>
+        </a>
+    </div>
     <div class="container py-5">
         <h3 class="mb-4">Watchlist</h3>
         <form method="POST" class="mb-3">


### PR DESCRIPTION
## Summary
- rename app to **MarketMinder**
- inject global `app_name` for templates
- show name header on every page
- update manifest and docs with the new name

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cad79765c8326a8eedce7196960d6