### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - env:
+          API_KEY: dummy
+        run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Flask-WTF
 APScheduler
 plotly
 psycopg2-binary
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+
+os.environ.setdefault('API_KEY', 'demo')
+
+from flask import url_for
+from stockapp import create_app
+
+@pytest.fixture
+def app(monkeypatch):
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    # prevent scheduler from running
+    monkeypatch.setattr('stockapp.__init__.start_scheduler', lambda: None)
+    app = create_app()
+    app.config['TESTING'] = True
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_index_route(client):
+    res = client.get('/')
+    assert res.status_code == 200
+    assert b'MarketMinder' in res.data
+
+def test_format_market_cap():
+    from stockapp.utils import format_market_cap
+    result = format_market_cap(1_500_000_000, 'USD')
+    assert 'B' in result


### PR DESCRIPTION
## Summary
- add pytest as dev dependency
- add minimal unit tests for index route and a util function
- add GitHub Actions workflow to run tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask)*

------
https://chatgpt.com/codex/tasks/task_e_685caf42c53083268ca35b193e11df38