### PR TITLE
Add health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ The codebase is organized as a Flask package named `stockapp`. The main `app.py`
 python app.py
 ```
 
+When deploying you can use `/health` to verify that the application is running.
+The endpoint simply returns `OK`.
+
 ### Default Login
 
 On startup the app creates a verified user if it doesn't already exist. The

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -21,6 +21,12 @@ def service_worker():
     return current_app.send_static_file('service-worker.js')
 
 
+@main_bp.route('/health')
+def health():
+    """Simple health check endpoint."""
+    return 'OK', 200
+
+
 @main_bp.route('/', methods=['GET', 'POST'])
 def index():
     symbol = ''

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,6 +24,12 @@ def test_index_route(client):
     assert res.status_code == 200
     assert b'MarketMinder' in res.data
 
+
+def test_health_route(client):
+    res = client.get('/health')
+    assert res.status_code == 200
+    assert res.data == b'OK'
+
 def test_format_market_cap():
     from stockapp.utils import format_market_cap
     result = format_market_cap(1_500_000_000, 'USD')


### PR DESCRIPTION
## Summary
- add `/health` route for basic monitoring
- document the new endpoint in the README
- test the new route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685dd4f4b2288326bc879189ad03cc95