### PR TITLE
Add ENABLE_SCHEDULER environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ store secrets in the source code:
   credentials for sending alert emails.
 * `FLASK_DEBUG` &ndash; Set to `1` to enable Flask debug mode (defaults to `0`).
 * `REDIS_URL` &ndash; Optional Redis connection string for caching API responses.
+* `ENABLE_SCHEDULER` &ndash; Set to `0` to disable background alert scheduling.
 
 Example:
 

--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -66,5 +66,6 @@ def create_app():
                 db.session.add(user)
                 db.session.commit()
 
-    start_scheduler()
+    if os.environ.get('ENABLE_SCHEDULER', 'true').lower() in ('1', 'true', 'yes'):
+        start_scheduler()
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,7 @@ def app(monkeypatch):
     os.environ.setdefault('API_KEY', 'demo')
     os.environ['DEFAULT_USERNAME'] = 'tester'
     os.environ['DEFAULT_PASSWORD'] = 'password'
-    # prevent scheduler from running
-    monkeypatch.setattr('stockapp.__init__.start_scheduler', lambda: None)
+    os.environ['ENABLE_SCHEDULER'] = '0'
     app = create_app()
     app.config['TESTING'] = True
     yield app


### PR DESCRIPTION
## Summary
- allow disabling scheduler startup via `ENABLE_SCHEDULER`
- document the new variable
- disable scheduler in tests using the env var

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6861d3800c188326b375cda3c7862503