### PR TITLE
Switch scheduled tasks to Celery

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ store secrets in the source code:
   credentials for sending alert emails.
 * `FLASK_DEBUG` &ndash; Set to `1` to enable Flask debug mode (defaults to `0`).
 * `REDIS_URL` &ndash; Optional Redis connection string for caching API responses.
-* `ENABLE_SCHEDULER` &ndash; Set to `0` to disable background alert scheduling.
+* `CELERY_BROKER_URL` &ndash; Message broker for background tasks (defaults to a local Redis instance).
+* `CELERY_RESULT_BACKEND` &ndash; Storage for Celery task results (defaults to the same Redis instance).
 
 Example:
 
@@ -38,6 +39,8 @@ export SMTP_USERNAME="user@example.com"
 export SMTP_PASSWORD="password"
 export FLASK_DEBUG=1
 export REDIS_URL="redis://localhost:6379/0"
+export CELERY_BROKER_URL="redis://localhost:6379/0"
+export CELERY_RESULT_BACKEND="redis://localhost:6379/0"
 ```
 
 ## Setup
@@ -55,6 +58,12 @@ The codebase is organized as a Flask package named `stockapp`. The main `app.py`
 
 ```bash
 python app.py
+```
+
+Start the Celery worker in a separate terminal so that scheduled tasks run:
+
+```bash
+celery -A stockapp.tasks.celery worker -B --loglevel=info
 ```
 
 When deploying you can use `/health` to verify that the application is running.
@@ -116,7 +125,7 @@ The main page also hosts several quick calculators:
 
 ## Scheduled Alerts
 
-Alert emails are sent on a schedule using **APScheduler**. Each user can
+Alert emails are sent on a schedule using **Celery**. Each user can
 configure how often their watchlist should be checked. Visit the *Settings*
 page after logging in to choose an alert frequency in hours. The default is 24
 hours. The background job runs hourly and only sends alerts when your selected

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ fpdf
 Flask-Login
 Flask-SQLAlchemy
 Flask-WTF
-APScheduler
+celery
 plotly
 psycopg2-binary
 pytest

--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -8,7 +8,7 @@ from .main import main_bp
 from .watchlists import watch_bp
 from .portfolio import portfolio_bp
 from .alerts import alerts_bp
-from .tasks import start_scheduler
+from .tasks import init_celery
 
 
 def create_app():
@@ -30,6 +30,13 @@ def create_app():
     app.config['SMTP_PORT'] = int(os.environ.get('SMTP_PORT', 587))
     app.config['SMTP_USERNAME'] = os.environ.get('SMTP_USERNAME', 'user@example.com')
     app.config['SMTP_PASSWORD'] = os.environ.get('SMTP_PASSWORD', 'password')
+
+    app.config['CELERY_BROKER_URL'] = os.environ.get(
+        'CELERY_BROKER_URL', 'redis://localhost:6379/0'
+    )
+    app.config['CELERY_RESULT_BACKEND'] = os.environ.get(
+        'CELERY_RESULT_BACKEND', 'redis://localhost:6379/0'
+    )
 
     db.init_app(app)
     login_manager.init_app(app)
@@ -66,6 +73,5 @@ def create_app():
                 db.session.add(user)
                 db.session.commit()
 
-    if os.environ.get('ENABLE_SCHEDULER', 'true').lower() in ('1', 'true', 'yes'):
-        start_scheduler()
+    init_celery(app)
     return app

--- a/stockapp/tasks.py
+++ b/stockapp/tasks.py
@@ -1,53 +1,79 @@
 from datetime import datetime, timedelta
-from apscheduler.schedulers.background import BackgroundScheduler
-import atexit
 
-from flask import current_app
+from celery import Celery
+from celery.schedules import crontab
+
 from .extensions import db
 from .models import User, WatchlistItem, Alert
 from .utils import get_stock_data, send_email, ALERT_PE_THRESHOLD
 
-scheduler = BackgroundScheduler()
+# Celery application instance configured in ``init_celery``.
+celery = Celery(__name__)
 
 
-def check_watchlists():
-    with current_app.app_context():
-        now = datetime.utcnow()
-        users = User.query.all()
-        for user in users:
-            if not user.email:
-                continue
-            freq = user.alert_frequency or 24
-            last = user.last_alert_time or datetime.min
-            if now - last < timedelta(hours=freq):
-                continue
-            items = WatchlistItem.query.filter_by(user_id=user.id).all()
-            for item in items:
-                (
-                    _name,
-                    _logo_url,
-                    _sector,
-                    _industry,
-                    _exchange,
-                    currency,
-                    price,
-                    eps,
-                    _market_cap,
-                    _debt_to_equity,
-                    *_rest,
-                ) = get_stock_data(item.symbol)
-                if price is not None and eps:
-                    pe_ratio = round(price / eps, 2)
-                    threshold = item.pe_threshold or ALERT_PE_THRESHOLD
-                    if pe_ratio > threshold:
-                        msg = f'{item.symbol} P/E ratio {pe_ratio} exceeds threshold {threshold}'
-                        send_email(user.email, 'P/E Ratio Alert', msg)
-                        db.session.add(Alert(symbol=item.symbol, message=msg, user_id=user.id))
-            user.last_alert_time = now
-        db.session.commit()
+def init_celery(app):
+    """Configure Celery with the Flask app context."""
+    celery.conf.update(
+        broker_url=app.config.get("CELERY_BROKER_URL", "redis://localhost:6379/0"),
+        result_backend=app.config.get(
+            "CELERY_RESULT_BACKEND", "redis://localhost:6379/0"
+        ),
+    )
+
+    class ContextTask(celery.Task):
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return super().__call__(*args, **kwargs)
+
+    celery.Task = ContextTask
+
+    celery.conf.beat_schedule = {
+        "check-watchlists-hourly": {
+            "task": "stockapp.tasks.check_watchlists_task",
+            "schedule": crontab(minute=0, hour="*"),
+        }
+    }
 
 
-def start_scheduler():
-    scheduler.add_job(check_watchlists, 'interval', hours=1)
-    scheduler.start()
-    atexit.register(lambda: scheduler.shutdown())
+def _check_watchlists():
+    """Check all user watchlists and send alerts when thresholds are exceeded."""
+    now = datetime.utcnow()
+    users = User.query.all()
+    for user in users:
+        if not user.email:
+            continue
+        freq = user.alert_frequency or 24
+        last = user.last_alert_time or datetime.min
+        if now - last < timedelta(hours=freq):
+            continue
+        items = WatchlistItem.query.filter_by(user_id=user.id).all()
+        for item in items:
+            (
+                _name,
+                _logo_url,
+                _sector,
+                _industry,
+                _exchange,
+                currency,
+                price,
+                eps,
+                _market_cap,
+                _debt_to_equity,
+                *_rest,
+            ) = get_stock_data(item.symbol)
+            if price is not None and eps:
+                pe_ratio = round(price / eps, 2)
+                threshold = item.pe_threshold or ALERT_PE_THRESHOLD
+                if pe_ratio > threshold:
+                    msg = f"{item.symbol} P/E ratio {pe_ratio} exceeds threshold {threshold}"
+                    send_email(user.email, "P/E Ratio Alert", msg)
+                    db.session.add(Alert(symbol=item.symbol, message=msg, user_id=user.id))
+        user.last_alert_time = now
+    db.session.commit()
+
+
+@celery.task(name="stockapp.tasks.check_watchlists_task")
+def check_watchlists_task():
+    """Celery task wrapper for ``_check_watchlists``."""
+    _check_watchlists()
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ def app(monkeypatch):
     os.environ.setdefault('API_KEY', 'demo')
     os.environ['DEFAULT_USERNAME'] = 'tester'
     os.environ['DEFAULT_PASSWORD'] = 'password'
-    os.environ['ENABLE_SCHEDULER'] = '0'
     app = create_app()
     app.config['TESTING'] = True
     yield app

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -67,7 +67,7 @@ def test_check_watchlists(app, monkeypatch):
         db.session.add(WatchlistItem(symbol='AAA', user_id=u.id, pe_threshold=10))
         db.session.commit()
     from stockapp import tasks
-    tasks.check_watchlists()
+    tasks._check_watchlists()
     assert emails
     with app.app_context():
         alert = Alert.query.filter_by(user_id=u.id).first()


### PR DESCRIPTION
## Summary
- replace APScheduler with Celery based tasks
- configure Celery in the Flask app factory
- document Celery configuration and worker usage
- update tests for new task function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6861db1082608326a45170e37764fd32