### PR TITLE
Expand tests and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,16 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements.txt
       - env:
           API_KEY: dummy
-        run: pytest
+        run: pytest -q

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,50 @@
+def test_download_csv(client, monkeypatch):
+    def fake_get_stock(symbol):
+        return (
+            'Test Corp', '', 'Tech', 'Software', 'NASDAQ', 'USD',
+            100, 5, '1B', 0.5, 1.1, 0.1, 0.05, 0.2,
+            'Buy', 0.03, 0.2, 0.15, 20, 5, 10, 15, 1.5
+        )
+    monkeypatch.setattr('stockapp.main.routes.get_stock_data', fake_get_stock)
+    resp = client.get('/download?symbol=AAA&format=csv')
+    assert resp.status_code == 200
+    assert resp.headers['Content-Type'] == 'text/csv'
+    assert b'Company Name' in resp.data
+
+
+def test_download_pdf(client, monkeypatch):
+    def fake_get_stock(symbol):
+        return (
+            'Test Corp', '', 'Tech', 'Software', 'NASDAQ', 'USD',
+            100, 5, '1B', 0.5, 1.1, 0.1, 0.05, 0.2,
+            'Buy', 0.03, 0.2, 0.15, 20, 5, 10, 15, 1.5
+        )
+    monkeypatch.setattr('stockapp.main.routes.get_stock_data', fake_get_stock)
+    resp = client.get('/download?symbol=AAA&format=pdf')
+    assert resp.status_code == 200
+    assert resp.headers['Content-Type'] == 'application/pdf'
+
+
+def test_loan_calculator(client):
+    data = {
+        'calc_type': 'loan',
+        'loan_amount': 1000,
+        'loan_rate': 5,
+        'loan_years': 1
+    }
+    resp = client.post('/', data=data)
+    assert b'Monthly Payment' in resp.data
+    assert b'Total Interest' in resp.data
+
+
+def test_export_portfolio_csv(auth_client, app):
+    from stockapp.models import User, PortfolioItem
+    from stockapp.extensions import db
+    with app.app_context():
+        user = User.query.filter_by(username='tester').first()
+        db.session.add(PortfolioItem(symbol='AAA', quantity=1, price_paid=10, user_id=user.id))
+        db.session.commit()
+    resp = auth_client.get('/export_portfolio')
+    assert resp.status_code == 200
+    assert resp.headers['Content-Type'] == 'text/csv'
+    assert b'Symbol,Quantity,Price Paid' in resp.data


### PR DESCRIPTION
## Summary
- add test coverage for CSV/PDF exports and loan calculator
- add portfolio export test
- test workflow across Python 3.10 and 3.11 and run `pytest -q`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6861e44874ac8326aa115385386d86dc