### PR TITLE
Add helper setup script for dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,16 @@ export CELERY_RESULT_BACKEND="redis://localhost:6379/0"
 
 ## Setup
 
-Install dependencies:
+Install dependencies and create a virtual environment by running the helper
+script included in the repository:
 
 ```bash
-pip install -r requirements.txt
+./setup_env.sh
+source venv/bin/activate
 ```
+
+The script creates a `venv/` directory in the project root and installs the
+packages listed in `requirements.txt`.
 
 Run the application:
 
@@ -64,6 +69,14 @@ Start the Celery worker in a separate terminal so that scheduled tasks run:
 
 ```bash
 celery -A stockapp.tasks.celery worker -B --loglevel=info
+```
+
+### Running Tests
+
+Once the virtual environment is active you can run the unit tests with:
+
+```bash
+pytest
 ```
 
 When deploying you can use `/health` to verify that the application is running.

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Simple helper script to create a Python virtual environment
+# and install project dependencies.
+set -e
+
+if [ -d "venv" ]; then
+    echo "Virtual environment already exists at ./venv" >&2
+else
+    python3 -m venv venv
+    echo "Created virtual environment in ./venv" >&2
+fi
+
+# Activate the environment
+source venv/bin/activate
+
+# Upgrade pip to avoid potential installation issues
+pip install --upgrade pip
+
+# Install required packages
+pip install -r requirements.txt
+
+echo "Environment is ready. Activate it with 'source venv/bin/activate'"


### PR DESCRIPTION
## Summary
- add `setup_env.sh` helper for quickly creating a virtualenv and installing dependencies
- document the script in the README and add instructions for running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686340c4bde483269b8a626b5132b8a6