### PR TITLE
Use Flask-WTF forms for core pages

### DIFF
--- a/stockapp/forms.py
+++ b/stockapp/forms.py
@@ -1,0 +1,40 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, FloatField, IntegerField, FileField
+from wtforms.validators import DataRequired, Email, Length, Optional
+
+
+class SignupForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired(), Length(max=64)])
+    email = StringField('Email', validators=[DataRequired(), Email(), Length(max=120)])
+    password = PasswordField('Password', validators=[DataRequired(), Length(min=4)])
+
+
+class LoginForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired(), Length(max=64)])
+    password = PasswordField('Password', validators=[DataRequired()])
+
+
+class WatchlistAddForm(FlaskForm):
+    symbol = StringField('Symbol', validators=[DataRequired(), Length(max=10)])
+    threshold = FloatField('Threshold', validators=[Optional()])
+
+
+class WatchlistUpdateForm(FlaskForm):
+    item_id = IntegerField('Item ID', validators=[DataRequired()])
+    threshold = FloatField('Threshold', validators=[DataRequired()])
+
+
+class PortfolioAddForm(FlaskForm):
+    symbol = StringField('Symbol', validators=[DataRequired(), Length(max=10)])
+    quantity = FloatField('Quantity', validators=[DataRequired()])
+    price_paid = FloatField('Price Paid', validators=[DataRequired()])
+
+
+class PortfolioUpdateForm(FlaskForm):
+    item_id = IntegerField('Item ID', validators=[DataRequired()])
+    quantity = FloatField('Quantity', validators=[Optional()])
+    price_paid = FloatField('Price Paid', validators=[Optional()])
+
+
+class PortfolioImportForm(FlaskForm):
+    file = FileField('File', validators=[DataRequired()])

--- a/templates/login.html
+++ b/templates/login.html
@@ -26,14 +26,14 @@
                         <div class="alert alert-info">{{ message }}</div>
                         {% endif %}
                         <form method="POST">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            {{ form.hidden_tag() }}
                             <div class="mb-3">
-                                <label for="username" class="form-label">Username</label>
-                                <input type="text" name="username" class="form-control" required>
+                                {{ form.username.label(class="form-label") }}
+                                {{ form.username(class="form-control") }}
                             </div>
                             <div class="mb-3">
-                                <label for="password" class="form-label">Password</label>
-                                <input type="password" name="password" class="form-control" required>
+                                {{ form.password.label(class="form-label") }}
+                                {{ form.password(class="form-control") }}
                             </div>
                             <div class="d-grid">
                                 <button type="submit" class="btn btn-primary">Login</button>

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -16,16 +16,16 @@
     <div class="container py-5">
         <h3 class="mb-4">Portfolio</h3>
         <form method="POST" class="mb-3">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {{ add_form.hidden_tag() }}
             <div class="row g-2">
                 <div class="col-md-3 col-sm-6">
-                    <input type="text" name="symbol" value="{{ symbol }}" class="form-control" placeholder="Ticker" required>
+                    {{ add_form.symbol(class="form-control", value=symbol, placeholder="Ticker") }}
                 </div>
                 <div class="col-md-3 col-sm-6">
-                    <input type="number" step="any" name="quantity" class="form-control" placeholder="Quantity" required>
+                    {{ add_form.quantity(class="form-control", placeholder="Quantity") }}
                 </div>
                 <div class="col-md-3 col-sm-6">
-                    <input type="number" step="any" name="price_paid" class="form-control" placeholder="Purchase Price" required>
+                    {{ add_form.price_paid(class="form-control", placeholder="Purchase Price") }}
                 </div>
                 <div class="col-md-3 col-sm-6 d-grid">
                     <button class="btn btn-primary" type="submit">Add</button>
@@ -35,8 +35,8 @@
         <div class="mb-3">
             <a href="{{ url_for('portfolio.export_portfolio') }}" class="btn btn-outline-secondary btn-sm">Export CSV</a>
             <form method="POST" enctype="multipart/form-data" class="d-inline-block ms-2">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <input type="file" name="file" accept=".csv" required class="form-control form-control-sm d-inline-block" style="width:auto; display:inline-block;">
+                {{ import_form.hidden_tag() }}
+                {{ import_form.file(class="form-control form-control-sm d-inline-block", accept=".csv", style="width:auto; display:inline-block;") }}
                 <button class="btn btn-outline-primary btn-sm" type="submit">Import CSV</button>
             </form>
         </div>
@@ -58,11 +58,11 @@
                     {% for row in items %}
                     <tr>
                         <form method="POST">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            <input type="hidden" name="item_id" value="{{ row.item.id }}">
+                            {{ update_form.csrf_token }}
+                            {{ update_form.item_id(value=row.item.id) }}
                             <td>{{ row.item.symbol }}</td>
-                            <td><input type="number" step="any" name="quantity" value="{{ row.item.quantity }}" class="form-control form-control-sm"></td>
-                            <td><input type="number" step="any" name="price_paid" value="{{ row.item.price_paid }}" class="form-control form-control-sm"></td>
+                            <td>{{ update_form.quantity(class="form-control form-control-sm", value=row.item.quantity) }}</td>
+                            <td>{{ update_form.price_paid(class="form-control form-control-sm", value=row.item.price_paid) }}</td>
                             <td>{{ row.current_price or 'N/A' }}</td>
                             <td>{{ row.value or 'N/A' }}</td>
                             <td>{{ row.profit_loss or 'N/A' }}</td>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -26,18 +26,18 @@
                         <div class="alert alert-info">{{ message }}</div>
                         {% endif %}
                         <form method="POST">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            {{ form.hidden_tag() }}
                             <div class="mb-3">
-                                <label for="username" class="form-label">Username</label>
-                                <input type="text" name="username" class="form-control" required>
+                                {{ form.username.label(class="form-label") }}
+                                {{ form.username(class="form-control") }}
                             </div>
                             <div class="mb-3">
-                                <label for="email" class="form-label">Email</label>
-                                <input type="email" name="email" class="form-control" required>
+                                {{ form.email.label(class="form-label") }}
+                                {{ form.email(class="form-control") }}
                             </div>
                             <div class="mb-3">
-                                <label for="password" class="form-label">Password</label>
-                                <input type="password" name="password" class="form-control" required>
+                                {{ form.password.label(class="form-label") }}
+                                {{ form.password(class="form-control") }}
                             </div>
                             <div class="d-grid">
                                 <button type="submit" class="btn btn-primary">Sign Up</button>

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -16,10 +16,10 @@
     <div class="container py-5">
         <h3 class="mb-4">Watchlist</h3>
         <form method="POST" class="mb-3">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {{ add_form.hidden_tag() }}
             <div class="input-group">
-                <input type="text" name="symbol" class="form-control" placeholder="Ticker symbol" required>
-                <input type="number" step="0.01" name="threshold" class="form-control" placeholder="P/E threshold" value="{{ default_threshold }}">
+                {{ add_form.symbol(class="form-control", placeholder="Ticker symbol") }}
+                {{ add_form.threshold(class="form-control", placeholder="P/E threshold", value=default_threshold) }}
                 <button class="btn btn-primary" type="submit">Add</button>
             </div>
         </form>
@@ -28,13 +28,13 @@
             {% for item in items %}
             <li class="list-group-item">
                 <form method="POST" class="d-flex justify-content-between align-items-center">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    {{ update_form.csrf_token }}
                     <div>
                         {{ item.symbol }}
-                        <input type="hidden" name="item_id" value="{{ item.id }}">
+                        {{ update_form.item_id(value=item.id) }}
                     </div>
                     <div class="input-group" style="width: 200px;">
-                        <input type="number" step="0.01" name="threshold" class="form-control form-control-sm" value="{{ item.pe_threshold }}">
+                        {{ update_form.threshold(class="form-control form-control-sm", value=item.pe_threshold) }}
                         <button class="btn btn-sm btn-primary" type="submit">Update</button>
                         <a href="{{ url_for('watch.delete_watchlist_item', item_id=item.id) }}" class="btn btn-sm btn-danger ms-1">Delete</a>
                     </div>


### PR DESCRIPTION
## Summary
- add dedicated WTForms classes
- refactor auth, watchlist and portfolio routes to use these forms
- update templates to render WTForms fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68634e1b7b9c83268437522b219a4b39