### PR TITLE
Improve SECRET_KEY default security

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ If `DATABASE_URL` is not provided, a local `app.db` SQLite file will be used.
 Several settings are loaded from environment variables so you do not need to
 store secrets in the source code:
 
-* `SECRET_KEY` &ndash; Flask session secret.
+* `SECRET_KEY` &ndash; Flask session secret. If omitted, a random key is generated
+  at startup (recommended to set in production).
 * `API_KEY` &ndash; Financial Modeling Prep API key (required).
 * `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD` &ndash; SMTP
   credentials for sending alert emails.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -37,7 +37,7 @@ import secrets
 
 app = Flask(__name__)
 # Load sensitive configuration from environment variables
-app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "change_this_secret")
+app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", secrets.token_hex(16))
 
 # Use DATABASE_URL if provided (e.g. when deployed on Render), otherwise
 # default to a local SQLite database.

--- a/stockapp/config.py
+++ b/stockapp/config.py
@@ -1,10 +1,11 @@
 import os
+import secrets
 
 
 class Config:
     """Base configuration with defaults suitable for production."""
 
-    SECRET_KEY = 'change_this_secret'
+    SECRET_KEY = secrets.token_hex(16)
     SQLALCHEMY_DATABASE_URI = 'sqlite:///app.db'
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 


### PR DESCRIPTION
## Summary
- generate a random SECRET_KEY when the environment variable isn't set
- document that auto-generation happens
- update legacy_app to use a secure default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68646fc645248326ad776263e517befb