### PR TITLE
Split calculators into new blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ columns `Symbol`, `Quantity` and `Price Paid`.
 
 ## Finance Calculators
 
-The main page also hosts several quick calculators:
+Several quick calculators are available at their own routes:
 
-* Simple interest
-* Compound interest
-* **Loan/Mortgage payment** – computes monthly payment, total interest and shows a full amortization schedule.
+* `/calc/interest` – simple interest
+* `/calc/compound` – compound interest
+* `/calc/loan` – **Loan/Mortgage payment** – computes monthly payment, total interest and shows a full amortization schedule.
 
 ## Scheduled Alerts
 

--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -8,6 +8,7 @@ from .main import main_bp
 from .watchlists import watch_bp
 from .portfolio import portfolio_bp
 from .alerts import alerts_bp
+from .calculators import calc_bp
 from .tasks import init_celery
 from .config import Config, DevelopmentConfig, ProductionConfig
 
@@ -50,6 +51,7 @@ def create_app(config_class=None):
     app.register_blueprint(watch_bp)
     app.register_blueprint(portfolio_bp)
     app.register_blueprint(alerts_bp)
+    app.register_blueprint(calc_bp)
 
     with app.app_context():
         db.create_all()

--- a/stockapp/calculators/__init__.py
+++ b/stockapp/calculators/__init__.py
@@ -1,0 +1,3 @@
+from .routes import calc_bp
+
+__all__ = ['calc_bp']

--- a/stockapp/calculators/routes.py
+++ b/stockapp/calculators/routes.py
@@ -1,0 +1,79 @@
+from flask import Blueprint, render_template, request
+
+calc_bp = Blueprint('calc', __name__, url_prefix='/calc')
+
+@calc_bp.route('/interest', methods=['GET', 'POST'])
+def interest():
+    interest_amount = interest_rate = interest_result = None
+    error_message = None
+    if request.method == 'POST':
+        try:
+            interest_amount = float(request.form.get('amount', 0))
+            interest_rate = float(request.form.get('rate', 0))
+            interest_result = round(interest_amount * interest_rate / 100, 2)
+        except ValueError:
+            error_message = 'Invalid amount or interest rate.'
+    return render_template('interest.html', interest_amount=interest_amount,
+                           interest_rate=interest_rate,
+                           interest_result=interest_result,
+                           error_message=error_message)
+
+@calc_bp.route('/compound', methods=['GET', 'POST'])
+def compound():
+    comp_principal = comp_rate = comp_years = comp_freq = comp_result = None
+    error_message = None
+    if request.method == 'POST':
+        try:
+            comp_principal = float(request.form.get('principal', 0))
+            comp_rate = float(request.form.get('rate', 0))
+            comp_years = float(request.form.get('years', 0))
+            comp_freq = int(request.form.get('frequency', 1))
+            comp_result = round(comp_principal * (1 + (comp_rate / 100) / comp_freq) ** (comp_freq * comp_years), 2)
+        except ValueError:
+            error_message = 'Invalid input for compound interest.'
+    return render_template('compound.html', comp_principal=comp_principal,
+                           comp_rate=comp_rate, comp_years=comp_years,
+                           comp_freq=comp_freq, comp_result=comp_result,
+                           error_message=error_message)
+
+@calc_bp.route('/loan', methods=['GET', 'POST'])
+def loan():
+    loan_amount = loan_rate = loan_years = None
+    loan_result = None
+    error_message = None
+    if request.method == 'POST':
+        try:
+            loan_amount = float(request.form.get('loan_amount', 0))
+            loan_rate = float(request.form.get('loan_rate', 0))
+            loan_years = float(request.form.get('loan_years', 0))
+            monthly_rate = loan_rate / 100 / 12
+            term_months = int(loan_years * 12)
+            if monthly_rate == 0:
+                monthly_payment = loan_amount / term_months
+            else:
+                monthly_payment = loan_amount * monthly_rate / (1 - (1 + monthly_rate) ** (-term_months))
+            total_payment = monthly_payment * term_months
+            total_interest = total_payment - loan_amount
+            balance = loan_amount
+            schedule = []
+            for i in range(1, term_months + 1):
+                interest_paid = balance * monthly_rate
+                principal_paid = monthly_payment - interest_paid
+                balance -= principal_paid
+                schedule.append({
+                    'month': i,
+                    'payment': round(monthly_payment, 2),
+                    'interest': round(interest_paid, 2),
+                    'principal': round(principal_paid, 2),
+                    'balance': round(max(balance, 0), 2),
+                })
+            loan_result = {
+                'monthly_payment': round(monthly_payment, 2),
+                'total_interest': round(total_interest, 2),
+                'schedule': schedule,
+            }
+        except ValueError:
+            error_message = 'Invalid input for loan calculator.'
+    return render_template('loan.html', loan_amount=loan_amount, loan_rate=loan_rate,
+                           loan_years=loan_years, loan_result=loan_result,
+                           error_message=error_message)

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -37,11 +37,7 @@ def index():
     peg_ratio = None
     error_message = alert_message = None
     history_dates = history_prices = []
-    interest_amount = interest_rate = interest_result = None
-    comp_principal = comp_rate = comp_years = comp_freq = comp_result = None
-    loan_amount = loan_rate = loan_years = None
-    loan_result = None
-    active_tab = 'pe'
+    # calculators moved to separate blueprint
 
     if request.method == 'GET':
         symbol = request.args.get('ticker', '').upper() or symbol
@@ -58,68 +54,9 @@ def index():
         history = session.get('history', [])
 
     if request.method == 'POST':
-        calc_type = request.form.get('calc_type')
-        if calc_type == 'interest':
-            active_tab = 'interest'
-            try:
-                interest_amount = float(request.form.get('amount', 0))
-                interest_rate = float(request.form.get('rate', 0))
-                interest_result = round(interest_amount * interest_rate / 100, 2)
-            except ValueError:
-                error_message = 'Invalid amount or interest rate.'
-        elif calc_type == 'compound':
-            active_tab = 'compound'
-            try:
-                comp_principal = float(request.form.get('principal', 0))
-                comp_rate = float(request.form.get('rate', 0))
-                comp_years = float(request.form.get('years', 0))
-                comp_freq = int(request.form.get('frequency', 1))
-                comp_result = round(
-                    comp_principal * (1 + (comp_rate / 100) / comp_freq) ** (comp_freq * comp_years),
-                    2,
-                )
-            except ValueError:
-                error_message = 'Invalid input for compound interest.'
-        elif calc_type == 'loan':
-            active_tab = 'loan'
-            try:
-                loan_amount = float(request.form.get('loan_amount', 0))
-                loan_rate = float(request.form.get('loan_rate', 0))
-                loan_years = float(request.form.get('loan_years', 0))
-                monthly_rate = loan_rate / 100 / 12
-                term_months = int(loan_years * 12)
-                if monthly_rate == 0:
-                    monthly_payment = loan_amount / term_months
-                else:
-                    monthly_payment = loan_amount * monthly_rate / (1 - (1 + monthly_rate) ** (-term_months))
-                total_payment = monthly_payment * term_months
-                total_interest = total_payment - loan_amount
-                balance = loan_amount
-                schedule = []
-                for i in range(1, term_months + 1):
-                    interest_paid = balance * monthly_rate
-                    principal_paid = monthly_payment - interest_paid
-                    balance -= principal_paid
-                    schedule.append(
-                        {
-                            'month': i,
-                            'payment': round(monthly_payment, 2),
-                            'interest': round(interest_paid, 2),
-                            'principal': round(principal_paid, 2),
-                            'balance': round(max(balance, 0), 2),
-                        }
-                    )
-                loan_result = {
-                    'monthly_payment': round(monthly_payment, 2),
-                    'total_interest': round(total_interest, 2),
-                    'schedule': schedule,
-                }
-            except ValueError:
-                error_message = 'Invalid input for loan calculator.'
-        else:
-            symbol = request.form['ticker'].upper()
+        symbol = request.form.get('ticker', '').upper()
 
-    if (request.method == 'POST' and request.form.get('calc_type') not in ['interest', 'compound', 'loan']) or symbol:
+    if symbol:
         try:
             (
                 company_name,
@@ -274,19 +211,6 @@ def index():
         history_dates=history_dates,
         history_prices=history_prices,
         history=history,
-        interest_amount=interest_amount,
-        interest_rate=interest_rate,
-        interest_result=interest_result,
-        comp_principal=comp_principal,
-        comp_rate=comp_rate,
-        comp_years=comp_years,
-        comp_freq=comp_freq,
-        comp_result=comp_result,
-        loan_amount=loan_amount,
-        loan_rate=loan_rate,
-        loan_years=loan_years,
-        loan_result=loan_result,
-        active_tab=active_tab,
     )
 
 

--- a/templates/compound.html
+++ b/templates/compound.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} - Compound Interest{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <h3 class="mb-4">Compound Interest</h3>
+    <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="mb-3">
+            <label for="principal" class="form-label">Principal</label>
+            <input type="number" step="any" id="principal" name="principal" value="{{ comp_principal }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="rate" class="form-label">Interest Rate (%)</label>
+            <input type="number" step="any" id="rate" name="rate" value="{{ comp_rate }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="years" class="form-label">Years</label>
+            <input type="number" step="any" id="years" name="years" value="{{ comp_years }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="frequency" class="form-label">Compounds per Year</label>
+            <input type="number" id="frequency" name="frequency" value="{{ comp_freq or 1 }}" class="form-control" required>
+        </div>
+        <div class="d-grid">
+            <button type="submit" class="btn btn-primary">Calculate</button>
+        </div>
+    </form>
+    {% if error_message %}
+        <div class="alert alert-danger mt-3">{{ error_message }}</div>
+    {% endif %}
+    {% if comp_result is not none %}
+        <p class="mt-3"><strong>Future Value:</strong> {{ comp_result }}</p>
+    {% endif %}
+    <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,7 @@
                 <a href="{{ url_for('alerts.alerts') }}" class="btn btn-sm btn-outline-primary me-2">Alerts</a>
                 <a href="{{ url_for('watch.records') }}" class="btn btn-sm btn-outline-primary me-2">Records</a>
                 <a href="{{ url_for('watch.export_history') }}" class="btn btn-sm btn-outline-secondary me-2">Export History</a>
+                <a href="{{ url_for('calc.interest') }}" class="btn btn-sm btn-outline-primary me-2">Calculators</a>
                 <a href="{{ url_for('watch.settings') }}" class="btn btn-sm btn-outline-secondary me-2">Settings</a>
                 <a href="{{ url_for('auth.logout') }}" class="btn btn-sm btn-danger">Logout</a>
             {% else %}
@@ -29,22 +30,7 @@
                 <div class="card shadow-sm">
                     <div class="card-body">
                         <h3 class="card-title text-center mb-4">{{ app_name }}</h3>
-                        <ul class="nav nav-tabs mb-3" id="calcTabs" role="tablist">
-                            <li class="nav-item" role="presentation">
-                                <button class="nav-link {% if active_tab == 'pe' %}active{% endif %}" id="pe-tab" data-bs-toggle="tab" data-bs-target="#pe" type="button" role="tab" aria-controls="pe" aria-selected="{{ 'true' if active_tab == 'pe' else 'false' }}">P/E Ratio</button>
-                            </li>
-                            <li class="nav-item" role="presentation">
-                                <button class="nav-link {% if active_tab == 'interest' %}active{% endif %}" id="interest-tab" data-bs-toggle="tab" data-bs-target="#interest" type="button" role="tab" aria-controls="interest" aria-selected="{{ 'true' if active_tab == 'interest' else 'false' }}">Interest</button>
-                            </li>
-                            <li class="nav-item" role="presentation">
-                                <button class="nav-link {% if active_tab == 'compound' %}active{% endif %}" id="compound-tab" data-bs-toggle="tab" data-bs-target="#compound" type="button" role="tab" aria-controls="compound" aria-selected="{{ 'true' if active_tab == 'compound' else 'false' }}">Compound Interest</button>
-                            </li>
-                            <li class="nav-item" role="presentation">
-                                <button class="nav-link {% if active_tab == 'loan' %}active{% endif %}" id="loan-tab" data-bs-toggle="tab" data-bs-target="#loan" type="button" role="tab" aria-controls="loan" aria-selected="{{ 'true' if active_tab == 'loan' else 'false' }}">Loan/Mortgage</button>
-                            </li>
-                        </ul>
-                        <div class="tab-content">
-                            <div class="tab-pane fade {% if active_tab == 'pe' %}show active{% endif %}" id="pe" role="tabpanel" aria-labelledby="pe-tab">
+                        <h5 class="mb-3">P/E Ratio Lookup</h5>
                                 <p class="small text-muted">The app also displays the PEG ratio (Price/Earnings-to-Growth), calculated by dividing the P/E ratio by the earnings growth rate. This highlights valuation relative to growth.</p>
                         <form method="GET">
                             <div class="mb-3">
@@ -194,105 +180,6 @@
                                 <a href="{{ url_for('main.download', symbol=symbol, format='pdf') }}" class="btn btn-secondary">Download PDF</a>
                             </div>
                         {% endif %}
-                            </div>
-                            <div class="tab-pane fade {% if active_tab == 'interest' %}show active{% endif %}" id="interest" role="tabpanel" aria-labelledby="interest-tab">
-                                <form method="POST">
-                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                    <input type="hidden" name="calc_type" value="interest">
-                                    <div class="mb-3">
-                                        <label for="amount" class="form-label">Amount</label>
-                                        <input type="number" step="any" id="amount" name="amount" value="{{ interest_amount }}" class="form-control" required>
-                                    </div>
-                                    <div class="mb-3">
-                                        <label for="rate" class="form-label">Interest Rate (%)</label>
-                                        <input type="number" step="any" id="rate" name="rate" value="{{ interest_rate }}" class="form-control" required>
-                                    </div>
-                                    <div class="d-grid">
-                                        <button type="submit" class="btn btn-primary">Calculate</button>
-                                    </div>
-                                </form>
-                                {% if interest_result is not none %}
-                                    <p class="mt-3"><strong>Interest Earned:</strong> {{ interest_result }}</p>
-                                {% endif %}
-                            </div>
-                            <div class="tab-pane fade {% if active_tab == 'compound' %}show active{% endif %}" id="compound" role="tabpanel" aria-labelledby="compound-tab">
-                                <form method="POST">
-                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                    <input type="hidden" name="calc_type" value="compound">
-                                    <div class="mb-3">
-                                        <label for="principal" class="form-label">Principal</label>
-                                        <input type="number" step="any" id="principal" name="principal" value="{{ comp_principal }}" class="form-control" required>
-                                    </div>
-                                    <div class="mb-3">
-                                        <label for="comp_rate" class="form-label">Interest Rate (%)</label>
-                                        <input type="number" step="any" id="comp_rate" name="rate" value="{{ comp_rate }}" class="form-control" required>
-                                    </div>
-                                    <div class="mb-3">
-                                        <label for="years" class="form-label">Years</label>
-                                        <input type="number" step="any" id="years" name="years" value="{{ comp_years }}" class="form-control" required>
-                                    </div>
-                                    <div class="mb-3">
-                                        <label for="frequency" class="form-label">Compounds per Year</label>
-                                        <input type="number" id="frequency" name="frequency" value="{{ comp_freq or 1 }}" class="form-control" required>
-                                    </div>
-                                    <div class="d-grid">
-                                        <button type="submit" class="btn btn-primary">Calculate</button>
-                                    </div>
-                                </form>
-                                {% if comp_result is not none %}
-                                    <p class="mt-3"><strong>Future Value:</strong> {{ comp_result }}</p>
-                                {% endif %}
-                            </div>
-                            <div class="tab-pane fade {% if active_tab == 'loan' %}show active{% endif %}" id="loan" role="tabpanel" aria-labelledby="loan-tab">
-                                <form method="POST">
-                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                    <input type="hidden" name="calc_type" value="loan">
-                                    <div class="mb-3">
-                                        <label for="loan_amount" class="form-label">Loan Amount</label>
-                                        <input type="number" step="any" id="loan_amount" name="loan_amount" value="{{ loan_amount }}" class="form-control" required>
-                                    </div>
-                                    <div class="mb-3">
-                                        <label for="loan_rate" class="form-label">Annual Interest Rate (%)</label>
-                                        <input type="number" step="any" id="loan_rate" name="loan_rate" value="{{ loan_rate }}" class="form-control" required>
-                                    </div>
-                                    <div class="mb-3">
-                                        <label for="loan_years" class="form-label">Term (Years)</label>
-                                        <input type="number" step="any" id="loan_years" name="loan_years" value="{{ loan_years }}" class="form-control" required>
-                                    </div>
-                                    <div class="d-grid">
-                                        <button type="submit" class="btn btn-primary">Calculate</button>
-                                    </div>
-                                </form>
-                                {% if loan_result %}
-                                    <p class="mt-3"><strong>Monthly Payment:</strong> {{ loan_result.monthly_payment }}</p>
-                                    <p><strong>Total Interest:</strong> {{ loan_result.total_interest }}</p>
-                                    <div class="table-responsive mt-3">
-                                        <table class="table table-sm">
-                                            <thead>
-                                                <tr>
-                                                    <th>Month</th>
-                                                    <th>Payment</th>
-                                                    <th>Interest</th>
-                                                    <th>Principal</th>
-                                                    <th>Balance</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                {% for row in loan_result.schedule %}
-                                                <tr>
-                                                    <td>{{ row.month }}</td>
-                                                    <td>{{ row.payment }}</td>
-                                                    <td>{{ row.interest }}</td>
-                                                    <td>{{ row.principal }}</td>
-                                                    <td>{{ row.balance }}</td>
-                                                </tr>
-                                                {% endfor %}
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                {% endif %}
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/templates/interest.html
+++ b/templates/interest.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} - Interest Calculator{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <h3 class="mb-4">Simple Interest</h3>
+    <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="mb-3">
+            <label for="amount" class="form-label">Amount</label>
+            <input type="number" step="any" id="amount" name="amount" value="{{ interest_amount }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="rate" class="form-label">Interest Rate (%)</label>
+            <input type="number" step="any" id="rate" name="rate" value="{{ interest_rate }}" class="form-control" required>
+        </div>
+        <div class="d-grid">
+            <button type="submit" class="btn btn-primary">Calculate</button>
+        </div>
+    </form>
+    {% if error_message %}
+        <div class="alert alert-danger mt-3">{{ error_message }}</div>
+    {% endif %}
+    {% if interest_result is not none %}
+        <p class="mt-3"><strong>Interest Earned:</strong> {{ interest_result }}</p>
+    {% endif %}
+    <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/templates/loan.html
+++ b/templates/loan.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} - Loan Calculator{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <h3 class="mb-4">Loan/Mortgage Calculator</h3>
+    <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="mb-3">
+            <label for="loan_amount" class="form-label">Loan Amount</label>
+            <input type="number" step="any" id="loan_amount" name="loan_amount" value="{{ loan_amount }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="loan_rate" class="form-label">Annual Interest Rate (%)</label>
+            <input type="number" step="any" id="loan_rate" name="loan_rate" value="{{ loan_rate }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="loan_years" class="form-label">Term (Years)</label>
+            <input type="number" step="any" id="loan_years" name="loan_years" value="{{ loan_years }}" class="form-control" required>
+        </div>
+        <div class="d-grid">
+            <button type="submit" class="btn btn-primary">Calculate</button>
+        </div>
+    </form>
+    {% if error_message %}
+        <div class="alert alert-danger mt-3">{{ error_message }}</div>
+    {% endif %}
+    {% if loan_result %}
+        <p class="mt-3"><strong>Monthly Payment:</strong> {{ loan_result.monthly_payment }}</p>
+        <p><strong>Total Interest:</strong> {{ loan_result.total_interest }}</p>
+        <div class="table-responsive mt-3">
+            <table class="table table-sm">
+                <thead>
+                    <tr>
+                        <th>Month</th>
+                        <th>Payment</th>
+                        <th>Interest</th>
+                        <th>Principal</th>
+                        <th>Balance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in loan_result.schedule %}
+                    <tr>
+                        <td>{{ row.month }}</td>
+                        <td>{{ row.payment }}</td>
+                        <td>{{ row.interest }}</td>
+                        <td>{{ row.principal }}</td>
+                        <td>{{ row.balance }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+    <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -27,12 +27,11 @@ def test_download_pdf(client, monkeypatch):
 
 def test_loan_calculator(client):
     data = {
-        'calc_type': 'loan',
         'loan_amount': 1000,
         'loan_rate': 5,
         'loan_years': 1
     }
-    resp = client.post('/', data=data)
+    resp = client.post('/calc/loan', data=data)
     assert b'Monthly Payment' in resp.data
     assert b'Total Interest' in resp.data
 


### PR DESCRIPTION
## Summary
- create `calculators` blueprint with separate interest, compound and loan routes
- simplify main index view to only handle stock lookups
- remove calculator tabs from the homepage and link to new calculator pages
- add templates for each calculator
- adjust tests for new `/calc/loan` endpoint
- document calculator routes in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68648c28bde4832695df9a0bdf0d8bdd