### PR TITLE
Add offline setup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ source venv/bin/activate
 The script creates a `venv/` directory in the project root and installs the
 packages listed in `requirements.txt`.
 
+If your environment does not have internet access you can install dependencies
+from a local **wheelhouse** directory instead. First, on a machine with
+connectivity, download the required packages:
+
+```bash
+pip download -d wheelhouse -r requirements.txt
+```
+
+Copy the generated `wheelhouse/` directory alongside this repository and run:
+
+```bash
+./setup_env.sh --offline
+```
+
+This tells the setup script to install packages using the local cache so tests
+can run without external network access.
+
 Run the application:
 
 The codebase is organized as a Flask package named `stockapp`. The main `app.py` file simply creates the Flask app from this package.

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -3,6 +3,11 @@
 # and install project dependencies.
 set -e
 
+OFFLINE=0
+if [[ "$1" == "--offline" ]]; then
+    OFFLINE=1
+fi
+
 if [ -d "venv" ]; then
     echo "Virtual environment already exists at ./venv" >&2
 else
@@ -17,6 +22,14 @@ source venv/bin/activate
 pip install --upgrade pip
 
 # Install required packages
-pip install -r requirements.txt
+if [ "$OFFLINE" -eq 1 ]; then
+    if [ ! -d "wheelhouse" ]; then
+        echo "Offline mode selected but wheelhouse directory not found" >&2
+        exit 1
+    fi
+    pip install --no-index --find-links=wheelhouse -r requirements.txt
+else
+    pip install -r requirements.txt
+fi
 
 echo "Environment is ready. Activate it with 'source venv/bin/activate'"


### PR DESCRIPTION
## Summary
- support offline dependency installation via `--offline` flag
- document wheelhouse usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68649c81495483269485baae87cf3a3f