### PR TITLE
Add news integration

### DIFF
--- a/stockapp/portfolio/routes.py
+++ b/stockapp/portfolio/routes.py
@@ -8,7 +8,12 @@ from ..extensions import db
 from ..models import PortfolioItem
 from statistics import correlation, stdev
 
-from ..utils import get_locale, get_stock_data, get_historical_prices
+from ..utils import (
+    get_locale,
+    get_stock_data,
+    get_historical_prices,
+    get_stock_news,
+)
 from ..forms import PortfolioAddForm, PortfolioUpdateForm, PortfolioImportForm
 
 portfolio_bp = Blueprint('portfolio', __name__)
@@ -204,6 +209,7 @@ def portfolio():
     else:
         correlations = []
         portfolio_volatility = None
+    news_data = {row['item'].symbol: get_stock_news(row['item'].symbol, limit=3) for row in data}
     return render_template(
         'portfolio.html',
         symbols=[row['item'].symbol for row in data],
@@ -214,6 +220,7 @@ def portfolio():
         risk_assessment=risk_assessment,
         correlations=correlations,
         portfolio_volatility=portfolio_volatility,
+        news=news_data,
         add_form=add_form,
         import_form=import_form,
         update_form=update_form,

--- a/stockapp/utils.py
+++ b/stockapp/utils.py
@@ -389,3 +389,34 @@ def get_stock_data(symbol):
     except Exception:
         logger.exception('Failed to fetch stock data for %s', symbol)
         return _cached_or_placeholder(cache_key)
+
+
+def get_stock_news(symbol, limit=3):
+    """Fetch recent news articles for a stock ticker."""
+    cache_key = ("news", symbol, limit)
+    cached = _get_cached(cache_key)
+    if cached:
+        return cached
+    url = (
+        f"https://financialmodelingprep.com/api/v3/stock_news?"
+        f"tickers={symbol}&limit={limit}&apikey={API_KEY}"
+    )
+    try:
+        data = _fetch_json(url, "news", symbol)
+        articles = []
+        if isinstance(data, list):
+            for item in data:
+                articles.append(
+                    {
+                        "headline": item.get("title"),
+                        "url": item.get("url"),
+                        "published": item.get("publishedDate"),
+                    }
+                )
+        if articles:
+            _set_cached(cache_key, articles)
+        return articles
+    except Exception:
+        logger.exception("Failed to fetch news for %s", symbol)
+        cached = _get_cached(cache_key)
+        return cached if cached else []

--- a/stockapp/watchlists/routes.py
+++ b/stockapp/watchlists/routes.py
@@ -12,7 +12,12 @@ from ..models import (
     History,
     StockRecord,
 )
-from ..utils import get_locale, ALERT_PE_THRESHOLD, get_stock_data
+from ..utils import (
+    get_locale,
+    ALERT_PE_THRESHOLD,
+    get_stock_data,
+    get_stock_news,
+)
 from ..forms import WatchlistAddForm, WatchlistUpdateForm
 
 watch_bp = Blueprint('watch', __name__)
@@ -40,7 +45,15 @@ def watchlist():
                     db.session.add(WatchlistItem(symbol=symbol, user_id=current_user.id, pe_threshold=threshold))
                     db.session.commit()
     items = WatchlistItem.query.filter_by(user_id=current_user.id).all()
-    return render_template('watchlist.html', items=items, add_form=add_form, update_form=update_form, default_threshold=ALERT_PE_THRESHOLD)
+    news = {i.symbol: get_stock_news(i.symbol, limit=3) for i in items}
+    return render_template(
+        'watchlist.html',
+        items=items,
+        add_form=add_form,
+        update_form=update_form,
+        default_threshold=ALERT_PE_THRESHOLD,
+        news=news,
+    )
 
 
 @watch_bp.route('/watchlist/delete/<int:item_id>')

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -63,6 +63,17 @@
         {% if portfolio_volatility is not none %}
         <div class="alert alert-warning">Portfolio Volatility: {{ portfolio_volatility }}%</div>
         {% endif %}
+        {% if news %}
+        <h5 class="mt-4">Latest News</h5>
+        {% for sym, articles in news.items() %}
+        <h6>{{ sym }}</h6>
+        <ul class="list-unstyled">
+            {% for n in articles %}
+            <li><a href="{{ n.url }}" target="_blank">{{ n.headline }}</a> <small class="text-muted">{{ n.published }}</small></li>
+            {% endfor %}
+        </ul>
+        {% endfor %}
+        {% endif %}
         {% else %}
         <p>No portfolio items.</p>
         {% endif %}

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -29,6 +29,16 @@
                         <a href="{{ url_for('watch.delete_watchlist', item_id=item.id) }}" class="btn btn-sm btn-danger">Delete</a>
                     </div>
                 </form>
+                {% if news[item.symbol] %}
+                <ul class="mt-2">
+                    {% for n in news[item.symbol] %}
+                    <li>
+                        <a href="{{ n.url }}" target="_blank">{{ n.headline }}</a>
+                        <small class="text-muted">{{ n.published }}</small>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
             </li>
             {% endfor %}
         </ul>

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -22,7 +22,8 @@ def test_signup_login_logout(client, app, monkeypatch):
     assert b'Login' in resp.data
 
 
-def test_watchlist_modifications(auth_client, app):
+def test_watchlist_modifications(auth_client, app, monkeypatch):
+    monkeypatch.setattr('stockapp.watchlists.routes.get_stock_news', lambda *a, **k: [])
     resp = auth_client.post('/watchlist', data={'symbol':'TEST','threshold':15}, follow_redirects=True)
     assert b'TEST' in resp.data
     with app.app_context():
@@ -37,6 +38,7 @@ def test_watchlist_modifications(auth_client, app):
 
 
 def test_portfolio_calculations(auth_client, app, monkeypatch):
+    monkeypatch.setattr('stockapp.portfolio.routes.get_stock_news', lambda *a, **k: [])
     def fake_get_stock_data(symbol):
         return (
             'Test Corp','', 'Tech','Software','NASDAQ','USD',
@@ -51,6 +53,7 @@ def test_portfolio_calculations(auth_client, app, monkeypatch):
 
 
 def test_portfolio_volatility_correlations(auth_client, app, monkeypatch):
+    monkeypatch.setattr('stockapp.portfolio.routes.get_stock_news', lambda *a, **k: [])
     def fake_get_stock_data(symbol):
         return (
             'Test Corp','', 'Tech','Software','NASDAQ','USD',


### PR DESCRIPTION
## Summary
- add `get_stock_news` utility for Financial Modeling Prep API
- fetch recent articles for watchlist and portfolio items
- render news sections on Watchlist and Portfolio pages
- patch tests to stub news fetcher

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865d0d43eb08326badc63d35ed462e9