### PR TITLE
Add technical indicator charts

### DIFF
--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -11,6 +11,8 @@ from ..utils import (
     get_historical_prices,
     get_locale,
     ALERT_PE_THRESHOLD,
+    moving_average,
+    calculate_rsi,
 )
 
 main_bp = Blueprint('main', __name__)
@@ -37,6 +39,7 @@ def index():
     peg_ratio = None
     error_message = alert_message = None
     history_dates = history_prices = []
+    ma20 = ma50 = rsi_values = []
     # calculators moved to separate blueprint
 
     if request.method == 'GET':
@@ -85,6 +88,9 @@ def index():
             ) = get_stock_data(symbol)
 
             history_dates, history_prices = get_historical_prices(symbol, days=90)
+            ma20 = moving_average(history_prices, 20)
+            ma50 = moving_average(history_prices, 50)
+            rsi_values = calculate_rsi(history_prices, 14)
 
             raw_price = price
             raw_eps = eps
@@ -210,6 +216,9 @@ def index():
         alert_message=alert_message,
         history_dates=history_dates,
         history_prices=history_prices,
+        ma20=ma20,
+        ma50=ma50,
+        rsi_values=rsi_values,
         history=history,
     )
 

--- a/stockapp/utils.py
+++ b/stockapp/utils.py
@@ -420,3 +420,40 @@ def get_stock_news(symbol, limit=3):
         logger.exception("Failed to fetch news for %s", symbol)
         cached = _get_cached(cache_key)
         return cached if cached else []
+
+
+def moving_average(prices, period):
+    """Simple moving average for a list of prices."""
+    ma = []
+    for i in range(len(prices)):
+        if i + 1 < period:
+            ma.append(None)
+        else:
+            window = prices[i + 1 - period : i + 1]
+            ma.append(round(sum(window) / period, 2))
+    return ma
+
+
+def calculate_rsi(prices, period=14):
+    """Calculate the Relative Strength Index (RSI)."""
+    rsi = []
+    for i in range(len(prices)):
+        if i < period:
+            rsi.append(None)
+            continue
+        gains = []
+        losses = []
+        for j in range(i - period + 1, i + 1):
+            change = prices[j] - prices[j - 1]
+            if change > 0:
+                gains.append(change)
+            else:
+                losses.append(abs(change))
+        avg_gain = sum(gains) / period if gains else 0
+        avg_loss = sum(losses) / period if losses else 0
+        if avg_loss == 0:
+            rsi.append(100)
+        else:
+            rs = avg_gain / avg_loss
+            rsi.append(round(100 - (100 / (1 + rs)), 2))
+    return rsi

--- a/templates/index.html
+++ b/templates/index.html
@@ -198,11 +198,15 @@
                                         </select>
                                     </div>
                                     <div id="priceChart"></div>
+                                    <div id="rsiChart" class="mt-3"></div>
                                 </div>
                                 <script>
                                     const fullDates = {{ history_dates|tojson }};
                                     const fullPrices = {{ history_prices|tojson }};
-                                    const layout = {
+                                    const ma20 = {{ ma20|tojson }};
+                                    const ma50 = {{ ma50|tojson }};
+                                    const rsiValues = {{ rsi_values|tojson }};
+                                    const priceLayout = {
                                         title: 'Historical Prices',
                                         xaxis: {
                                             title: 'Date',
@@ -213,8 +217,26 @@
                                     function updateChart(days) {
                                         const dates = fullDates.slice(-days);
                                         const prices = fullPrices.slice(-days);
-                                        const data = [{ x: dates, y: prices, mode: 'lines', name: 'Price' }];
-                                        Plotly.react('priceChart', data, layout, {responsive: true});
+                                        const ma20Data = ma20.slice(-days);
+                                        const ma50Data = ma50.slice(-days);
+                                        const rsi = rsiValues.slice(-days);
+                                        const priceData = [
+                                            { x: dates, y: prices, mode: 'lines', name: 'Price' },
+                                            { x: dates, y: ma20Data, mode: 'lines', name: 'MA20' },
+                                            { x: dates, y: ma50Data, mode: 'lines', name: 'MA50' }
+                                        ];
+                                        Plotly.react('priceChart', priceData, priceLayout, {responsive: true});
+                                        const rsiLayout = {
+                                            title: 'RSI',
+                                            xaxis: { title: 'Date' },
+                                            yaxis: { title: 'RSI', range: [0, 100] },
+                                            shapes: [
+                                                {type: 'line', x0: dates[0], x1: dates[dates.length-1], y0: 70, y1: 70, line: {dash: 'dash', width: 1, color: 'red'}},
+                                                {type: 'line', x0: dates[0], x1: dates[dates.length-1], y0: 30, y1: 30, line: {dash: 'dash', width: 1, color: 'green'}}
+                                            ]
+                                        };
+                                        const rsiData = [{ x: dates, y: rsi, mode: 'lines', name: 'RSI' }];
+                                        Plotly.react('rsiChart', rsiData, rsiLayout, {responsive: true});
                                     }
                                     document.getElementById('timeRange').addEventListener('change', (e) => {
                                         updateChart(parseInt(e.target.value));

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,6 +17,15 @@ def test_format_market_cap():
     assert 'B' in result
 
 
+def test_indicators():
+    from stockapp.utils import moving_average, calculate_rsi
+    prices = [1, 2, 3, 4, 5]
+    ma = moving_average(prices, 3)
+    assert ma[-1] == 4
+    rsi = calculate_rsi(prices, 3)
+    assert rsi[-1] == 100
+
+
 def test_api_endpoints(auth_client, app):
     from stockapp.models import WatchlistItem, PortfolioItem, Alert, User
     from stockapp.extensions import db


### PR DESCRIPTION
## Summary
- implement `moving_average` and `calculate_rsi` utility helpers
- compute MA20, MA50 and RSI in the index route and expose to templates
- extend the price chart with moving averages and add an RSI plot
- test the new indicator helpers

## Testing
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865d501e2f483269a45a325ffb4fdaa