### PR TITLE
Add notes and tags

### DIFF
--- a/stockapp/api/routes.py
+++ b/stockapp/api/routes.py
@@ -11,7 +11,14 @@ api_bp = Blueprint("api", __name__, url_prefix="/api")
 def get_watchlist():
     items = WatchlistItem.query.filter_by(user_id=current_user.id).all()
     data = [
-        {"id": i.id, "symbol": i.symbol, "pe_threshold": i.pe_threshold} for i in items
+        {
+            "id": i.id,
+            "symbol": i.symbol,
+            "pe_threshold": i.pe_threshold,
+            "notes": i.notes,
+            "tags": i.tags,
+        }
+        for i in items
     ]
     return jsonify(data)
 
@@ -26,6 +33,8 @@ def get_portfolio():
             "symbol": i.symbol,
             "quantity": i.quantity,
             "price_paid": i.price_paid,
+            "notes": i.notes,
+            "tags": i.tags,
         }
         for i in items
     ]

--- a/stockapp/forms.py
+++ b/stockapp/forms.py
@@ -4,37 +4,45 @@ from wtforms.validators import DataRequired, Email, Length, Optional
 
 
 class SignupForm(FlaskForm):
-    username = StringField('Username', validators=[DataRequired(), Length(max=64)])
-    email = StringField('Email', validators=[DataRequired(), Email(), Length(max=120)])
-    password = PasswordField('Password', validators=[DataRequired(), Length(min=4)])
+    username = StringField("Username", validators=[DataRequired(), Length(max=64)])
+    email = StringField("Email", validators=[DataRequired(), Email(), Length(max=120)])
+    password = PasswordField("Password", validators=[DataRequired(), Length(min=4)])
 
 
 class LoginForm(FlaskForm):
-    username = StringField('Username', validators=[DataRequired(), Length(max=64)])
-    password = PasswordField('Password', validators=[DataRequired()])
+    username = StringField("Username", validators=[DataRequired(), Length(max=64)])
+    password = PasswordField("Password", validators=[DataRequired()])
 
 
 class WatchlistAddForm(FlaskForm):
-    symbol = StringField('Symbol', validators=[DataRequired(), Length(max=10)])
-    threshold = FloatField('Threshold', validators=[Optional()])
+    symbol = StringField("Symbol", validators=[DataRequired(), Length(max=10)])
+    threshold = FloatField("Threshold", validators=[Optional()])
+    notes = StringField("Notes", validators=[Optional(), Length(max=200)])
+    tags = StringField("Tags", validators=[Optional(), Length(max=100)])
 
 
 class WatchlistUpdateForm(FlaskForm):
-    item_id = IntegerField('Item ID', validators=[DataRequired()])
-    threshold = FloatField('Threshold', validators=[DataRequired()])
+    item_id = IntegerField("Item ID", validators=[DataRequired()])
+    threshold = FloatField("Threshold", validators=[DataRequired()])
+    notes = StringField("Notes", validators=[Optional(), Length(max=200)])
+    tags = StringField("Tags", validators=[Optional(), Length(max=100)])
 
 
 class PortfolioAddForm(FlaskForm):
-    symbol = StringField('Symbol', validators=[DataRequired(), Length(max=10)])
-    quantity = FloatField('Quantity', validators=[DataRequired()])
-    price_paid = FloatField('Price Paid', validators=[DataRequired()])
+    symbol = StringField("Symbol", validators=[DataRequired(), Length(max=10)])
+    quantity = FloatField("Quantity", validators=[DataRequired()])
+    price_paid = FloatField("Price Paid", validators=[DataRequired()])
+    notes = StringField("Notes", validators=[Optional(), Length(max=200)])
+    tags = StringField("Tags", validators=[Optional(), Length(max=100)])
 
 
 class PortfolioUpdateForm(FlaskForm):
-    item_id = IntegerField('Item ID', validators=[DataRequired()])
-    quantity = FloatField('Quantity', validators=[Optional()])
-    price_paid = FloatField('Price Paid', validators=[Optional()])
+    item_id = IntegerField("Item ID", validators=[DataRequired()])
+    quantity = FloatField("Quantity", validators=[Optional()])
+    price_paid = FloatField("Price Paid", validators=[Optional()])
+    notes = StringField("Notes", validators=[Optional(), Length(max=200)])
+    tags = StringField("Tags", validators=[Optional(), Length(max=100)])
 
 
 class PortfolioImportForm(FlaskForm):
-    file = FileField('File', validators=[DataRequired()])
+    file = FileField("File", validators=[DataRequired()])

--- a/stockapp/models.py
+++ b/stockapp/models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from flask_login import UserMixin
 from .extensions import db
 
+
 class User(db.Model, UserMixin):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(150), unique=True, nullable=False)
@@ -17,29 +18,36 @@ class User(db.Model, UserMixin):
     mfa_expiry = db.Column(db.DateTime)
     mfa_secret = db.Column(db.String(32))
 
+
 class WatchlistItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     symbol = db.Column(db.String(10), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     pe_threshold = db.Column(db.Float, default=30)
+    notes = db.Column(db.Text)
+    tags = db.Column(db.String(100))
+
 
 class FavoriteTicker(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     symbol = db.Column(db.String(10), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+
 
 class Alert(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     symbol = db.Column(db.String(10))
     message = db.Column(db.String(200))
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+
 
 class History(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     symbol = db.Column(db.String(10))
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+
 
 class StockRecord(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -48,11 +56,14 @@ class StockRecord(db.Model):
     eps = db.Column(db.Float)
     pe_ratio = db.Column(db.Float)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+
 
 class PortfolioItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     symbol = db.Column(db.String(10), nullable=False)
     quantity = db.Column(db.Float, nullable=False)
     price_paid = db.Column(db.Float, nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    notes = db.Column(db.Text)
+    tags = db.Column(db.String(100))

--- a/stockapp/portfolio/routes.py
+++ b/stockapp/portfolio/routes.py
@@ -16,45 +16,49 @@ from ..utils import (
 )
 from ..forms import PortfolioAddForm, PortfolioUpdateForm, PortfolioImportForm
 
-portfolio_bp = Blueprint('portfolio', __name__)
+portfolio_bp = Blueprint("portfolio", __name__)
 
-@portfolio_bp.route('/export_portfolio')
+
+@portfolio_bp.route("/export_portfolio")
 @login_required
 def export_portfolio():
     items = PortfolioItem.query.filter_by(user_id=current_user.id).all()
     output = io.StringIO()
     writer = csv.writer(output)
-    writer.writerow(['Symbol', 'Quantity', 'Price Paid'])
+    writer.writerow(["Symbol", "Quantity", "Price Paid"])
     for item in items:
         writer.writerow([item.symbol, item.quantity, item.price_paid])
     response = make_response(output.getvalue())
-    response.headers['Content-Disposition'] = 'attachment; filename=portfolio.csv'
-    response.headers['Content-Type'] = 'text/csv'
+    response.headers["Content-Disposition"] = "attachment; filename=portfolio.csv"
+    response.headers["Content-Type"] = "text/csv"
     return response
 
-@portfolio_bp.route('/portfolio', methods=['GET', 'POST'])
+
+@portfolio_bp.route("/portfolio", methods=["GET", "POST"])
 @login_required
 def portfolio():
-    symbol_prefill = request.args.get('symbol', '').upper()
+    symbol_prefill = request.args.get("symbol", "").upper()
     add_form = PortfolioAddForm(symbol=symbol_prefill)
     import_form = PortfolioImportForm()
     update_form = PortfolioUpdateForm()
 
-    if request.method == 'POST':
-        if request.files.get('file'):
+    if request.method == "POST":
+        if request.files.get("file"):
             if import_form.validate_on_submit():
-                file = request.files['file']
-                content = file.read().decode('utf-8')
+                file = request.files["file"]
+                content = file.read().decode("utf-8")
                 reader = csv.DictReader(io.StringIO(content))
                 for row in reader:
-                    symbol = row.get('Symbol', '').upper()
+                    symbol = row.get("Symbol", "").upper()
                     try:
-                        quantity = float(row.get('Quantity', 0))
-                        price_paid = float(row.get('Price Paid', 0))
+                        quantity = float(row.get("Quantity", 0))
+                        price_paid = float(row.get("Price Paid", 0))
                     except (TypeError, ValueError):
                         continue
                     if symbol and quantity and price_paid:
-                        if not PortfolioItem.query.filter_by(user_id=current_user.id, symbol=symbol).first():
+                        if not PortfolioItem.query.filter_by(
+                            user_id=current_user.id, symbol=symbol
+                        ).first():
                             db.session.add(
                                 PortfolioItem(
                                     symbol=symbol,
@@ -64,31 +68,41 @@ def portfolio():
                                 )
                             )
                 db.session.commit()
-        elif request.form.get('item_id'):
+        elif request.form.get("item_id"):
             if update_form.validate_on_submit():
                 item_id = update_form.item_id.data
                 quantity = update_form.quantity.data
                 price_paid = update_form.price_paid.data
+                notes = update_form.notes.data
+                tags = update_form.tags.data
                 item = PortfolioItem.query.get_or_404(item_id)
                 if item.user_id == current_user.id:
                     if quantity is not None:
                         item.quantity = quantity
                     if price_paid is not None:
                         item.price_paid = price_paid
+                    item.notes = notes
+                    item.tags = tags
                     db.session.commit()
         else:
             if add_form.validate_on_submit():
                 symbol = add_form.symbol.data.upper()
                 quantity = add_form.quantity.data
                 price_paid = add_form.price_paid.data
+                notes = add_form.notes.data
+                tags = add_form.tags.data
                 if quantity is not None and price_paid is not None:
-                    if not PortfolioItem.query.filter_by(user_id=current_user.id, symbol=symbol).first():
+                    if not PortfolioItem.query.filter_by(
+                        user_id=current_user.id, symbol=symbol
+                    ).first():
                         db.session.add(
                             PortfolioItem(
                                 symbol=symbol,
                                 quantity=quantity,
                                 price_paid=price_paid,
                                 user_id=current_user.id,
+                                notes=notes,
+                                tags=tags,
                             )
                         )
                         db.session.commit()
@@ -126,51 +140,53 @@ def portfolio():
             value_num = 0
         data.append(
             {
-                'item': item,
-                'current_price': current_price,
-                'value': value,
-                'profit_loss': pl,
-                'price_num': price,
-                'value_num': value_num,
+                "item": item,
+                "current_price": current_price,
+                "value": value,
+                "profit_loss": pl,
+                "price_num": price,
+                "value_num": value_num,
             }
         )
     totals = None
     if items and totals_currency:
         totals = {
-            'value': format_currency(total_value, totals_currency, locale=get_locale()),
-            'profit_loss': format_currency(total_pl, totals_currency, locale=get_locale()),
+            "value": format_currency(total_value, totals_currency, locale=get_locale()),
+            "profit_loss": format_currency(
+                total_pl, totals_currency, locale=get_locale()
+            ),
         }
     diversification = []
     risk_assessment = None
     if total_value > 0:
         for sec, val in sector_totals.items():
             pct = round(val / total_value * 100, 2)
-            diversification.append({'sector': sec, 'percentage': pct})
-        diversification.sort(key=lambda x: x['percentage'], reverse=True)
+            diversification.append({"sector": sec, "percentage": pct})
+        diversification.sort(key=lambda x: x["percentage"], reverse=True)
         if diversification:
             top = diversification[0]
-            if top['percentage'] > 50:
+            if top["percentage"] > 50:
                 risk_assessment = f"High concentration in {top['sector']}"
-            elif top['percentage'] > 30:
+            elif top["percentage"] > 30:
                 risk_assessment = f"Moderate concentration in {top['sector']}"
             else:
-                risk_assessment = 'Well diversified across sectors.'
+                risk_assessment = "Well diversified across sectors."
         # Calculate correlations and portfolio volatility
         returns = {}
         weights = {}
         for row in data:
-            sym = row['item'].symbol
-            price_num = row['price_num']
+            sym = row["item"].symbol
+            price_num = row["price_num"]
             if price_num is None:
                 continue
-            weights[sym] = row['value_num'] / total_value if total_value else 0
+            weights[sym] = row["value_num"] / total_value if total_value else 0
             _dates, prices = get_historical_prices(sym, days=30)
             if len(prices) > 1:
                 r = []
                 for i in range(1, len(prices)):
                     try:
-                        if prices[i-1]:
-                            r.append((prices[i] - prices[i-1]) / prices[i-1])
+                        if prices[i - 1]:
+                            r.append((prices[i] - prices[i - 1]) / prices[i - 1])
                     except Exception:
                         pass
                 if r:
@@ -186,7 +202,9 @@ def portfolio():
                     if n > 1:
                         try:
                             c = correlation(r1[-n:], r2[-n:])
-                            correlations.append({'pair': f'{syms[i]}-{syms[j]}', 'value': round(c, 2)})
+                            correlations.append(
+                                {"pair": f"{syms[i]}-{syms[j]}", "value": round(c, 2)}
+                            )
                         except Exception:
                             pass
         portfolio_volatility = None
@@ -202,17 +220,19 @@ def portfolio():
                     portfolio_returns.append(day_ret)
                 if len(portfolio_returns) > 1:
                     try:
-                        vol = stdev(portfolio_returns) * (252 ** 0.5)
+                        vol = stdev(portfolio_returns) * (252**0.5)
                         portfolio_volatility = round(vol * 100, 2)
                     except Exception:
                         portfolio_volatility = None
     else:
         correlations = []
         portfolio_volatility = None
-    news_data = {row['item'].symbol: get_stock_news(row['item'].symbol, limit=3) for row in data}
+    news_data = {
+        row["item"].symbol: get_stock_news(row["item"].symbol, limit=3) for row in data
+    }
     return render_template(
-        'portfolio.html',
-        symbols=[row['item'].symbol for row in data],
+        "portfolio.html",
+        symbols=[row["item"].symbol for row in data],
         items=data,
         symbol=symbol_prefill,
         totals=totals,
@@ -226,11 +246,12 @@ def portfolio():
         update_form=update_form,
     )
 
-@portfolio_bp.route('/portfolio/delete/<int:item_id>')
+
+@portfolio_bp.route("/portfolio/delete/<int:item_id>")
 @login_required
 def delete_portfolio_item(item_id):
     item = PortfolioItem.query.get_or_404(item_id)
     if item.user_id == current_user.id:
         db.session.delete(item)
         db.session.commit()
-    return redirect(url_for('portfolio.portfolio'))
+    return redirect(url_for("portfolio.portfolio"))

--- a/stockapp/watchlists/routes.py
+++ b/stockapp/watchlists/routes.py
@@ -20,34 +20,50 @@ from ..utils import (
 )
 from ..forms import WatchlistAddForm, WatchlistUpdateForm
 
-watch_bp = Blueprint('watch', __name__)
+watch_bp = Blueprint("watch", __name__)
 
 
-@watch_bp.route('/watchlist', methods=['GET', 'POST'])
+@watch_bp.route("/watchlist", methods=["GET", "POST"])
 @login_required
 def watchlist():
     add_form = WatchlistAddForm()
     update_form = WatchlistUpdateForm()
-    if request.method == 'POST':
-        if request.form.get('item_id'):
+    if request.method == "POST":
+        if request.form.get("item_id"):
             if update_form.validate_on_submit():
                 item_id = update_form.item_id.data
                 threshold = update_form.threshold.data
+                notes = update_form.notes.data
+                tags = update_form.tags.data
                 item = WatchlistItem.query.get_or_404(item_id)
                 if item.user_id == current_user.id:
                     item.pe_threshold = threshold or ALERT_PE_THRESHOLD
+                    item.notes = notes
+                    item.tags = tags
                     db.session.commit()
         else:
             if add_form.validate_on_submit():
                 symbol = add_form.symbol.data.upper()
                 threshold = add_form.threshold.data or ALERT_PE_THRESHOLD
-                if not WatchlistItem.query.filter_by(user_id=current_user.id, symbol=symbol).first():
-                    db.session.add(WatchlistItem(symbol=symbol, user_id=current_user.id, pe_threshold=threshold))
+                notes = add_form.notes.data
+                tags = add_form.tags.data
+                if not WatchlistItem.query.filter_by(
+                    user_id=current_user.id, symbol=symbol
+                ).first():
+                    db.session.add(
+                        WatchlistItem(
+                            symbol=symbol,
+                            user_id=current_user.id,
+                            pe_threshold=threshold,
+                            notes=notes,
+                            tags=tags,
+                        )
+                    )
                     db.session.commit()
     items = WatchlistItem.query.filter_by(user_id=current_user.id).all()
     news = {i.symbol: get_stock_news(i.symbol, limit=3) for i in items}
     return render_template(
-        'watchlist.html',
+        "watchlist.html",
         items=items,
         add_form=add_form,
         update_form=update_form,
@@ -56,70 +72,80 @@ def watchlist():
     )
 
 
-@watch_bp.route('/watchlist/delete/<int:item_id>')
+@watch_bp.route("/watchlist/delete/<int:item_id>")
 @login_required
 def delete_watchlist_item(item_id):
     item = WatchlistItem.query.get_or_404(item_id)
     if item.user_id == current_user.id:
         db.session.delete(item)
         db.session.commit()
-    return redirect(url_for('watch.watchlist'))
+    return redirect(url_for("watch.watchlist"))
 
 
-@watch_bp.route('/add_watchlist/<symbol>')
+@watch_bp.route("/add_watchlist/<symbol>")
 @login_required
 def add_watchlist(symbol):
     symbol = symbol.upper()
-    if not WatchlistItem.query.filter_by(user_id=current_user.id, symbol=symbol).first():
-        db.session.add(WatchlistItem(symbol=symbol, user_id=current_user.id, pe_threshold=ALERT_PE_THRESHOLD))
+    if not WatchlistItem.query.filter_by(
+        user_id=current_user.id, symbol=symbol
+    ).first():
+        db.session.add(
+            WatchlistItem(
+                symbol=symbol, user_id=current_user.id, pe_threshold=ALERT_PE_THRESHOLD
+            )
+        )
         db.session.commit()
-    return redirect(url_for('main.index', ticker=symbol))
+    return redirect(url_for("main.index", ticker=symbol))
 
 
-@watch_bp.route('/favorites', methods=['GET', 'POST'])
+@watch_bp.route("/favorites", methods=["GET", "POST"])
 @login_required
 def favorites():
-    if request.method == 'POST':
-        symbol = request.form['symbol'].upper()
-        if not FavoriteTicker.query.filter_by(user_id=current_user.id, symbol=symbol).first():
+    if request.method == "POST":
+        symbol = request.form["symbol"].upper()
+        if not FavoriteTicker.query.filter_by(
+            user_id=current_user.id, symbol=symbol
+        ).first():
             db.session.add(FavoriteTicker(symbol=symbol, user_id=current_user.id))
             db.session.commit()
     items = FavoriteTicker.query.filter_by(user_id=current_user.id).all()
-    return render_template('favorites.html', items=items)
+    return render_template("favorites.html", items=items)
 
 
-@watch_bp.route('/favorites/delete/<int:item_id>')
+@watch_bp.route("/favorites/delete/<int:item_id>")
 @login_required
 def delete_favorite(item_id):
     item = FavoriteTicker.query.get_or_404(item_id)
     if item.user_id == current_user.id:
         db.session.delete(item)
         db.session.commit()
-    return redirect(url_for('watch.favorites'))
+    return redirect(url_for("watch.favorites"))
 
 
-@watch_bp.route('/add_favorite/<symbol>')
+@watch_bp.route("/add_favorite/<symbol>")
 @login_required
 def add_favorite(symbol):
     symbol = symbol.upper()
-    if not FavoriteTicker.query.filter_by(user_id=current_user.id, symbol=symbol).first():
+    if not FavoriteTicker.query.filter_by(
+        user_id=current_user.id, symbol=symbol
+    ).first():
         db.session.add(FavoriteTicker(symbol=symbol, user_id=current_user.id))
         db.session.commit()
-    return redirect(url_for('main.index', ticker=symbol))
+    return redirect(url_for("main.index", ticker=symbol))
 
 
-@watch_bp.route('/settings', methods=['GET', 'POST'])
+@watch_bp.route("/settings", methods=["GET", "POST"])
 @login_required
 def settings():
-    if request.method == 'POST':
-        freq = request.form.get('frequency', type=int)
+    if request.method == "POST":
+        freq = request.form.get("frequency", type=int)
         if freq and freq > 0:
             current_user.alert_frequency = freq
             db.session.commit()
-    return render_template('settings.html', frequency=current_user.alert_frequency)
+    return render_template("settings.html", frequency=current_user.alert_frequency)
 
 
-@watch_bp.route('/export_history')
+@watch_bp.route("/export_history")
 @login_required
 def export_history():
     entries = (
@@ -129,19 +155,17 @@ def export_history():
     )
     output = io.StringIO()
     writer = csv.writer(output)
-    writer.writerow(['Symbol', 'Timestamp'])
+    writer.writerow(["Symbol", "Timestamp"])
     for e in entries:
         timestamp = format_datetime(e.timestamp, locale=get_locale())
         writer.writerow([e.symbol, timestamp])
     response = make_response(output.getvalue())
-    response.headers['Content-Disposition'] = 'attachment; filename=history.csv'
-    response.headers['Content-Type'] = 'text/csv'
+    response.headers["Content-Disposition"] = "attachment; filename=history.csv"
+    response.headers["Content-Type"] = "text/csv"
     return response
 
 
-
-
-@watch_bp.route('/records')
+@watch_bp.route("/records")
 @login_required
 def records():
     entries = (
@@ -149,12 +173,12 @@ def records():
         .order_by(StockRecord.timestamp.desc())
         .all()
     )
-    return render_template('records.html', records=entries)
+    return render_template("records.html", records=entries)
 
 
-@watch_bp.route('/clear_records')
+@watch_bp.route("/clear_records")
 @login_required
 def clear_records():
     StockRecord.query.filter_by(user_id=current_user.id).delete()
     db.session.commit()
-    return redirect(url_for('watch.records'))
+    return redirect(url_for("watch.records"))

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -22,6 +22,12 @@
                 <div class="col">
                     <input type="number" name="price_paid" step="any" class="form-control" placeholder="Price Paid" required>
                 </div>
+                <div class="col">
+                    {{ add_form.notes(class="form-control", placeholder="Notes") }}
+                </div>
+                <div class="col">
+                    {{ add_form.tags(class="form-control", placeholder="Tags") }}
+                </div>
                 <div class="col-auto">
                     <button class="btn btn-primary" type="submit">Add</button>
                 </div>
@@ -35,6 +41,8 @@
                         <th>Symbol</th>
                         <th>Quantity</th>
                         <th>Price Paid</th>
+                        <th>Notes</th>
+                        <th>Tags</th>
                         <th>Actions</th>
                     </tr>
                 </thead>
@@ -44,6 +52,8 @@
                         <td>{{ item.symbol }}</td>
                         <td>{{ item.quantity }}</td>
                         <td>{{ item.price_paid }}</td>
+                        <td>{{ item.notes }}</td>
+                        <td>{{ item.tags }}</td>
                         <td>
                             <a href="{{ url_for('portfolio.delete_portfolio', item_id=item.id) }}" class="btn btn-sm btn-danger">Delete</a>
                         </td>

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -7,24 +7,36 @@
         <h3 class="mb-4">Watchlist</h3>
         <form method="POST" class="mb-3">
             {{ add_form.hidden_tag() }}
-            <div class="input-group">
-                {{ add_form.symbol(class="form-control", placeholder="Symbol") }}
-                {{ add_form.threshold(class="form-control", placeholder="P/E Threshold") }}
-                <button class="btn btn-primary" type="submit">Add</button>
+            <div class="row g-2">
+                <div class="col">
+                    {{ add_form.symbol(class="form-control", placeholder="Symbol") }}
+                </div>
+                <div class="col">
+                    {{ add_form.threshold(class="form-control", placeholder="P/E Threshold") }}
+                </div>
+                <div class="col">
+                    {{ add_form.notes(class="form-control", placeholder="Notes") }}
+                </div>
+                <div class="col">
+                    {{ add_form.tags(class="form-control", placeholder="Tags") }}
+                </div>
+                <div class="col-auto">
+                    <button class="btn btn-primary" type="submit">Add</button>
+                </div>
             </div>
         </form>
         {% if items %}
         <ul class="list-group">
             {% for item in items %}
             <li class="list-group-item">
-                <form method="POST" class="d-flex justify-content-between align-items-center">
+                <form method="POST" class="d-flex flex-column gap-2">
                     {{ update_form.hidden_tag() }}
                     <input type="hidden" name="item_id" value="{{ item.id }}">
-                    <div>
-                        {{ item.symbol }} -
+                    <div class="d-flex align-items-center gap-2">
+                        <strong>{{ item.symbol }}</strong>
                         <input type="number" name="threshold" value="{{ item.pe_threshold }}" class="form-control d-inline-block w-auto" />
-                    </div>
-                    <div>
+                        <input type="text" name="notes" value="{{ item.notes or '' }}" class="form-control" placeholder="Notes" />
+                        <input type="text" name="tags" value="{{ item.tags or '' }}" class="form-control" placeholder="Tags" />
                         <button class="btn btn-sm btn-primary" type="submit">Update</button>
                         <a href="{{ url_for('watch.delete_watchlist', item_id=item.id) }}" class="btn btn-sm btn-danger">Delete</a>
                     </div>


### PR DESCRIPTION
## Summary
- enable adding notes and tags to `WatchlistItem` and `PortfolioItem`
- expose notes and tags in REST API
- allow entering notes/tags in forms and display them in templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865d6414c14832684102b24f1412a15