### PR TITLE
Expand test coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ def app(monkeypatch):
     os.environ['DEFAULT_PASSWORD'] = 'password'
     app = create_app()
     app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    from stockapp import tasks
+    tasks.celery.conf.update(task_always_eager=True)
     yield app
 
 @pytest.fixture

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -1,0 +1,42 @@
+import pytest
+
+from stockapp.forms import SignupForm, LoginForm
+from stockapp.tasks import check_watchlists_task
+
+
+def test_download_errors(client, monkeypatch):
+    monkeypatch.setattr(
+        'stockapp.main.routes.get_stock_data',
+        lambda s: (
+            'Test', '', '', '', 'NASDAQ', 'USD',
+            100, 5, '1B', None, None, None, None, None, None,
+            None, None, None, None, None, None, None, None
+        )
+    )
+    resp = client.get('/download')
+    assert resp.status_code == 400
+    resp = client.get('/download?symbol=AAA&format=bogus')
+    assert resp.status_code == 400
+
+
+def test_form_validation(app):
+    with app.test_request_context():
+        form = SignupForm(meta={'csrf': False}, data={'username': '', 'email': 'bad', 'password': ''})
+        assert not form.validate()
+        form2 = LoginForm(meta={'csrf': False}, data={'username': '', 'password': ''})
+        assert not form2.validate()
+
+
+def test_celery_task_invocation(monkeypatch):
+    called = []
+    monkeypatch.setattr('stockapp.tasks._check_watchlists', lambda: called.append(True))
+    check_watchlists_task()
+    assert called
+
+
+def test_api_requires_login(client):
+    for endpoint in ['/api/watchlist', '/api/portfolio', '/api/alerts']:
+        resp = client.get(endpoint)
+        assert resp.status_code in (302, 401)
+        if resp.status_code == 302:
+            assert '/login' in resp.headers['Location']


### PR DESCRIPTION
## Summary
- disable CSRF in tests and run Celery tasks eagerly
- add new tests for error cases, form validation, Celery task behavior and unauthenticated API access

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68661bbfd754832681c3079805fb8087