### PR TITLE
Add dotenv support and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Example configuration for MarketMinder
+# Copy this file to `.env` and adjust the values as needed.
+
+SECRET_KEY=changeme
+API_KEY=your_fmp_api_key
+#DATABASE_URL=postgresql://user:pass@localhost/dbname
+SMTP_SERVER=smtp.example.com
+SMTP_PORT=587
+SMTP_USERNAME=user@example.com
+SMTP_PASSWORD=password
+REDIS_URL=redis://localhost:6379/0
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
+TWILIO_SID=
+TWILIO_TOKEN=
+TWILIO_FROM=
+FLASK_ENV=development
+FLASK_DEBUG=1

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ dist/
 app.db
 *.sqlite3
 
+# Environment files
+.env
+
 # Misc
 .DS_Store
 *.swp

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ store secrets in the source code:
 * `CELERY_RESULT_BACKEND` &ndash; Storage for Celery task results (defaults to the same Redis instance).
 * `TWILIO_SID`, `TWILIO_TOKEN`, `TWILIO_FROM` &ndash; Optional credentials for sending SMS notifications.
 
+You can place these settings in a `.env` file in the project root. They will be
+loaded automatically when the app starts thanks to **python-dotenv**. An
+`/.env.example` file is provided with common options. Copy it to `.env` and
+adjust the values for your environment.
+
 Example:
 
 ```bash
@@ -92,6 +97,13 @@ Start the Celery worker in a separate terminal so that scheduled tasks run:
 ```bash
 celery -A stockapp.tasks.celery worker -B --loglevel=info
 ```
+
+### Production Configuration
+
+For production deployments you should provide your own Redis instance and
+configure Celery to use it. Set `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND`
+to the Redis connection string (e.g. `redis://hostname:6379/0`). The same Redis
+URL can be assigned to `REDIS_URL` if you want API caching enabled.
 
 ### Running Tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ plotly
 psycopg2-binary
 pytest
 redis
+python-dotenv

--- a/stockapp/config.py
+++ b/stockapp/config.py
@@ -1,5 +1,10 @@
 import os
 import secrets
+from pathlib import Path
+from dotenv import load_dotenv
+
+# Load variables from a .env file if present
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
 
 class Config:


### PR DESCRIPTION
## Summary
- ignore `.env`
- support python-dotenv in config
- provide `.env.example`
- mention `.env` usage and production Redis settings in README
- include python-dotenv in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68661c997884832694ca228750656e5e