### PR TITLE
Serve frontend assets locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ app.db
 # Misc
 .DS_Store
 *.swp
+node_modules/

--- a/README.md
+++ b/README.md
@@ -199,3 +199,17 @@ The app registers a small service worker so it can behave like a Progressive
 Web App. Only static assets are cached. The main pages are always fetched from
 the server so that dynamic CSRF tokens stay valid.
 
+### Frontend Assets
+
+Bootstrap and Plotly are now managed locally instead of pulled from a CDN. A
+small build script copies the files from `node_modules` into `static/vendor`.
+Run the following once after cloning:
+
+```bash
+npm install
+npm run build
+```
+
+This populates the `static/vendor/` directory so the service worker can cache
+the assets even when offline.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pe-ratio-app-assets",
+  "version": "1.0.0",
+  "description": "Frontend asset management for PE ratio app",
+  "private": true,
+  "devDependencies": {
+    "bootstrap": "5.3.2",
+    "plotly.js-dist-min": "^2"
+  },
+  "scripts": {
+    "build": "node scripts/build_assets.js"
+  }
+}

--- a/scripts/build_assets.js
+++ b/scripts/build_assets.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+function copy(src, dest) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+}
+
+function main() {
+  const paths = [
+    [
+      'node_modules/bootstrap/dist/css/bootstrap.min.css',
+      'static/vendor/bootstrap.min.css'
+    ],
+    [
+      'node_modules/bootstrap/dist/js/bootstrap.bundle.min.js',
+      'static/vendor/bootstrap.bundle.min.js'
+    ],
+    [
+      'node_modules/plotly.js-dist-min/plotly.min.js',
+      'static/vendor/plotly.min.js'
+    ],
+  ];
+
+  for (const [src, dest] of paths) {
+    if (fs.existsSync(src)) {
+      copy(src, dest);
+      console.log(`Copied ${src} -> ${dest}`);
+    } else {
+      console.warn(`Missing ${src}, did you run \`npm install\`?`);
+    }
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -3,8 +3,9 @@ const urlsToCache = [
   '/static/manifest.json',
   '/static/icons/icon-192.png',
   '/static/icons/icon-512.png',
-  'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css',
-  'https://cdn.plot.ly/plotly-latest.min.js'
+  '/static/vendor/bootstrap.min.css',
+  '/static/vendor/bootstrap.bundle.min.js',
+  '/static/vendor/plotly.min.js'
 ];
 
 self.addEventListener('install', event => {

--- a/static/vendor/README.md
+++ b/static/vendor/README.md
@@ -1,0 +1,2 @@
+This directory stores third-party frontend assets.
+Run `npm install` and `npm run build` to populate it with Bootstrap and Plotly files.

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{{ app_name }}{% endblock %}</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='vendor/bootstrap.min.css') }}" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
     {% block head %}{% endblock %}
 </head>
@@ -43,7 +43,7 @@
         </div>
     </nav>
     {% block content %}{% endblock %}
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='vendor/bootstrap.bundle.min.js') }}"></script>
     {% block scripts %}{% endblock %}
     <script>
         if ('serviceWorker' in navigator) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block head %}
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    <script src="{{ url_for('static', filename='vendor/plotly.min.js') }}"></script>
 {% endblock %}
 
 {% block content %}

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -4,7 +4,7 @@
 
 {% block head %}
     {{ super() }}
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    <script src="{{ url_for('static', filename='vendor/plotly.min.js') }}"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- host Bootstrap and Plotly locally instead of CDN
- add npm build script for copying assets
- update service worker to cache local resources
- document frontend asset build steps
- ignore node_modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `./setup_env.sh --offline` *(fails: Offline mode selected but wheelhouse directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661f60bdfc83269bbd18e7d1e9bdf7