### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+venv
+__pycache__
+*.py[cod]
+*.pyo
+node_modules
+static/vendor
+wheelhouse

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+# Install system dependencies for building and frontend assets
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential nodejs npm && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Build frontend assets
+COPY package.json ./package.json
+COPY scripts ./scripts
+RUN npm install && npm run build
+
+COPY . .
+
+EXPOSE 5000
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "app:app"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ This Flask application calculates P/E ratios and stores user data using SQLAlche
    For scheduled alerts run a Celery worker. See [docs/advanced_features.md](docs/advanced_features.md) for details.
 5. Run the tests with `pytest`.
 
+### Docker Compose
+
+A `docker-compose.yml` file is provided to run the app along with Redis, Celery and PostgreSQL. Build and start the stack with:
+
+```bash
+docker compose up --build
+```
+
+The web interface will be available at http://localhost:5000.
+
 Additional documentation can be found in [docs/advanced_features.md](docs/advanced_features.md) and [docs/contributing.md](docs/contributing.md).
 ## Database Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    command: gunicorn -b 0.0.0.0:5000 app:app
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/marketminder
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - REDIS_URL=redis://redis:6379/0
+      - SECRET_KEY=changeme
+      - API_KEY=dummy
+    ports:
+      - "5000:5000"
+    depends_on:
+      - db
+      - redis
+
+  worker:
+    build: .
+    command: celery -A stockapp.tasks.celery worker -B --loglevel=info
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/marketminder
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - REDIS_URL=redis://redis:6379/0
+      - SECRET_KEY=changeme
+      - API_KEY=dummy
+    depends_on:
+      - db
+      - redis
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: marketminder
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose setup
- ignore development files with .dockerignore
- document how to start the stack with Docker Compose

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: cannot connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_6866256aa0888326ab12d236d0648399