### PR TITLE
Add customizable user preferences

### DIFF
--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -65,6 +65,9 @@ def create_app(config_class=None):
                     username=default_user,
                     password_hash=generate_password_hash(default_pass),
                     is_verified=True,
+                    default_currency="USD",
+                    language="en",
+                    theme="light",
                 )
                 db.session.add(user)
                 db.session.commit()

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -137,6 +137,9 @@ def index():
                 current_ratio,
             ) = get_stock_data(symbol)
 
+            if current_user.is_authenticated and current_user.default_currency:
+                currency = current_user.default_currency
+
             history_dates, history_prices = get_historical_prices(symbol, days=90)
             ma20 = moving_average(history_prices, 20)
             ma50 = moving_average(history_prices, 50)
@@ -345,6 +348,9 @@ def download():
         price_to_fcf,
         current_ratio,
     ) = get_stock_data(symbol)
+
+    if current_user.is_authenticated and current_user.default_currency:
+        currency = current_user.default_currency
 
     if price is not None and eps:
         pe_ratio_val = round(price / eps, 2)

--- a/stockapp/models.py
+++ b/stockapp/models.py
@@ -21,6 +21,10 @@ class User(db.Model, UserMixin):
     mfa_code = db.Column(db.String(20))
     mfa_expiry = db.Column(db.DateTime)
     mfa_secret = db.Column(db.String(32))
+    default_currency = db.Column(db.String(3), default="USD")
+    language = db.Column(db.String(5), default="en")
+    theme = db.Column(db.String(10), default="light")
+
 
 
 class WatchlistItem(db.Model):

--- a/stockapp/portfolio/helpers.py
+++ b/stockapp/portfolio/helpers.py
@@ -4,6 +4,7 @@ import io
 from typing import Callable, Dict, List, Tuple
 from statistics import correlation, stdev
 from babel.numbers import format_currency
+from flask_login import current_user
 
 from ..extensions import db
 from ..models import PortfolioItem
@@ -103,6 +104,8 @@ def calculate_portfolio_analysis(
             price,
             *_rest,
         ) = get_stock_data_func(item.symbol)
+        if current_user.is_authenticated and current_user.default_currency:
+            currency = current_user.default_currency
         if price is not None:
             current_price = format_currency(price, currency, locale=get_locale())
             value_num = price * item.quantity

--- a/stockapp/utils.py
+++ b/stockapp/utils.py
@@ -6,6 +6,7 @@ import requests
 import smtplib
 from email.mime.text import MIMEText
 from flask import current_app, has_request_context, request
+from flask_login import current_user
 from babel import Locale
 from babel.numbers import format_currency, format_decimal
 from babel.dates import format_datetime
@@ -118,6 +119,8 @@ def _cached_or_placeholder(key, size=23):
 
 def get_locale():
     if has_request_context():
+        if current_user.is_authenticated and current_user.language:
+            return current_user.language
         loc = request.accept_languages.best or "en_US"
         try:
             return str(Locale.parse(loc))

--- a/stockapp/watchlists/routes.py
+++ b/stockapp/watchlists/routes.py
@@ -144,12 +144,24 @@ def settings():
         phone = request.form.get("phone")
         current_user.phone_number = phone
         current_user.sms_opt_in = bool(request.form.get("sms_opt_in"))
+        currency = request.form.get("currency")
+        language = request.form.get("language")
+        theme = request.form.get("theme")
+        if currency:
+            current_user.default_currency = currency
+        if language:
+            current_user.language = language
+        if theme in ("light", "dark"):
+            current_user.theme = theme
         db.session.commit()
     return render_template(
         "settings.html",
         frequency=current_user.alert_frequency,
         phone=current_user.phone_number or "",
         sms_opt_in=current_user.sms_opt_in,
+        currency=current_user.default_currency,
+        language=current_user.language,
+        theme=current_user.theme,
     )
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ current_user.language if current_user.is_authenticated else 'en' }}" data-bs-theme="{{ current_user.theme if current_user.is_authenticated else 'light' }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -8,13 +8,13 @@
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
     {% block head %}{% endblock %}
 </head>
-<body class="bg-light">
+<body class="{% if current_user.is_authenticated and current_user.theme=='dark' %}bg-dark text-white{% else %}bg-light{% endif %}">
     <div class="bg-primary text-white text-center py-2 mb-3">
         <a href="{{ url_for('main.index') }}" class="text-white text-decoration-none">
             <h1 class="h3 m-0">{{ app_name }}</h1>
         </a>
     </div>
-    <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
+    <nav class="navbar navbar-expand-lg {% if current_user.is_authenticated and current_user.theme=='dark' %}navbar-dark bg-dark{% else %}navbar-light bg-white{% endif %} shadow-sm">
         <div class="container">
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -15,6 +15,23 @@
                 <input class="form-check-input" type="checkbox" name="sms_opt_in" id="sms_opt_in" {% if sms_opt_in %}checked{% endif %}>
                 <label class="form-check-label" for="sms_opt_in">Enable SMS Alerts</label>
             </div>
+            <label class="form-label mt-3">Default Currency</label>
+            <select name="currency" class="form-select">
+                {% for cur in ['USD','EUR','GBP','AUD','JPY'] %}
+                    <option value="{{ cur }}" {% if currency==cur %}selected{% endif %}>{{ cur }}</option>
+                {% endfor %}
+            </select>
+            <label class="form-label mt-3">Language</label>
+            <select name="language" class="form-select">
+                {% for lang in ['en','es','fr','de'] %}
+                    <option value="{{ lang }}" {% if language==lang %}selected{% endif %}>{{ lang }}</option>
+                {% endfor %}
+            </select>
+            <label class="form-label mt-3">Theme</label>
+            <select name="theme" class="form-select">
+                <option value="light" {% if theme=='light' %}selected{% endif %}>Light</option>
+                <option value="dark" {% if theme=='dark' %}selected{% endif %}>Dark</option>
+            </select>
             <button class="btn btn-primary mt-3" type="submit">Save</button>
         </form>
         <a href="{{ url_for('main.index') }}" class="btn btn-secondary">Back</a>

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -248,3 +248,18 @@ def test_mfa_login_flow(client, app):
     code = totp.now()
     resp = client.post("/mfa_verify", data={"code": code}, follow_redirects=True)
     assert b"MarketMinder" in resp.data
+
+
+def test_user_preferences_update(auth_client):
+    resp = auth_client.post(
+        "/settings",
+        data={
+            "frequency": 12,
+            "phone": "111",
+            "currency": "EUR",
+            "language": "fr",
+            "theme": "dark",
+        },
+        follow_redirects=True,
+    )
+    assert b"EUR" in resp.data


### PR DESCRIPTION
## Summary
- add default_currency, language and theme fields to `User`
- save user preference settings on settings page
- use preferences when formatting currency and locale
- support dark mode and selected language in templates
- test updating user preferences

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68671efc400483269577202a35a54b84