### PR TITLE
Add public watchlists and following

### DIFF
--- a/stockapp/forms.py
+++ b/stockapp/forms.py
@@ -28,6 +28,7 @@ class WatchlistAddForm(FlaskForm):
     threshold = FloatField("Threshold", validators=[Optional()])
     notes = StringField("Notes", validators=[Optional(), Length(max=200)])
     tags = StringField("Tags", validators=[Optional(), Length(max=100)])
+    public = BooleanField("Public")
 
 
 class WatchlistUpdateForm(FlaskForm):
@@ -35,6 +36,7 @@ class WatchlistUpdateForm(FlaskForm):
     threshold = FloatField("Threshold", validators=[DataRequired()])
     notes = StringField("Notes", validators=[Optional(), Length(max=200)])
     tags = StringField("Tags", validators=[Optional(), Length(max=100)])
+    public = BooleanField("Public")
 
 
 class PortfolioAddForm(FlaskForm):

--- a/stockapp/models.py
+++ b/stockapp/models.py
@@ -34,6 +34,7 @@ class WatchlistItem(db.Model):
     pe_threshold = db.Column(db.Float, default=30)
     notes = db.Column(db.Text)
     tags = db.Column(db.String(100))
+    is_public = db.Column(db.Boolean, default=False)
 
 
 class FavoriteTicker(db.Model):
@@ -75,3 +76,9 @@ class PortfolioItem(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     notes = db.Column(db.Text)
     tags = db.Column(db.String(100))
+
+
+class PortfolioFollow(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    follower_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    followed_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)

--- a/templates/public_portfolio.html
+++ b/templates/public_portfolio.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Portfolio{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h3 class="mb-4">{{ user.username }}'s Portfolio</h3>
+  {% if following %}
+  <a href="{{ url_for('portfolio.follow_portfolio', username=user.username) }}" class="btn btn-secondary mb-3">Unfollow</a>
+  {% else %}
+  <a href="{{ url_for('portfolio.follow_portfolio', username=user.username) }}" class="btn btn-primary mb-3">Follow</a>
+  {% endif %}
+  {% if items %}
+  <ul class="list-group">
+    {% for item in items %}
+    <li class="list-group-item">
+      <strong>{{ item.symbol }}</strong> - {{ item.quantity }} @ {{ item.price_paid }}
+    </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>No holdings.</p>
+  {% endif %}
+  <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/templates/public_watchlist.html
+++ b/templates/public_watchlist.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Public Watchlist{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h3 class="mb-4">{{ user.username }}'s Public Watchlist</h3>
+  {% if items %}
+  <ul class="list-group">
+    {% for item in items %}
+    <li class="list-group-item">
+      <strong>{{ item.symbol }}</strong>
+      {% if news[item.symbol] %}
+      <ul class="mt-2">
+        {% for n in news[item.symbol] %}
+        <li>
+          <a href="{{ n.url }}" target="_blank">{{ n.headline }}</a>
+          <small class="text-muted">{{ n.published }}</small>
+        </li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>No public items.</p>
+  {% endif %}
+  <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -20,6 +20,10 @@
                 <div class="col">
                     {{ add_form.tags(class="form-control", placeholder="Tags") }}
                 </div>
+                <div class="col-auto form-check">
+                    {{ add_form.public(class="form-check-input") }}
+                    <label class="form-check-label">Public</label>
+                </div>
                 <div class="col-auto">
                     <button class="btn btn-primary" type="submit">Add</button>
                 </div>
@@ -37,9 +41,13 @@
                         <input type="number" name="threshold" value="{{ item.pe_threshold }}" class="form-control d-inline-block w-auto" />
                         <input type="text" name="notes" value="{{ item.notes or '' }}" class="form-control" placeholder="Notes" />
                         <input type="text" name="tags" value="{{ item.tags or '' }}" class="form-control" placeholder="Tags" />
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="public" {% if item.is_public %}checked{% endif %}>
+                            <label class="form-check-label">Public</label>
+                        </div>
                         <button class="btn btn-sm btn-primary" type="submit">Update</button>
-                        <a href="{{ url_for('watch.delete_watchlist', item_id=item.id) }}" class="btn btn-sm btn-danger">Delete</a>
-                    </div>
+                        <a href="{{ url_for('watch.delete_watchlist_item', item_id=item.id) }}" class="btn btn-sm btn-danger">Delete</a>
+                        </div>
                 </form>
                 {% if news[item.symbol] %}
                 <ul class="mt-2">


### PR DESCRIPTION
## Summary
- allow watchlist items to be marked public
- display another user's public watchlist
- enable following another user's portfolio and viewing their holdings
- add templates for public watchlists/portfolios
- test new social features

## Testing
- `black .`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6867216b29948326afdddbb5022397bd