### PR TITLE
Add XLSX and JSON export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ Alongside the standard P/E ratio the app now fetches and displays:
 * **Dividend Payout Ratio** – shows what percentage of earnings are distributed as dividends.
 * **Current Ratio** – current assets divided by current liabilities, indicating short-term liquidity.
 
-These extra metrics appear on the main page and in exported CSV/PDF files.
+These extra metrics appear on the main page and in exported CSV/PDF/XLSX/JSON files.
 
-## Portfolio CSV Import/Export
+## Portfolio CSV/XLSX/JSON Import/Export
 
-Within the Portfolio page you can now export all holdings to a CSV file or
+Within the Portfolio page you can now export all holdings to CSV, XLSX or JSON files or
 import a file to quickly populate your portfolio. The CSV format uses the
 columns `Symbol`, `Quantity` and `Price Paid`.
 

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -15,9 +15,6 @@ import io
 from fpdf import FPDF
 from babel.numbers import format_currency, format_decimal
 import json
-import time
-from ..extensions import db
-from ..models import History, Alert, WatchlistItem, StockRecord
 from ..utils import (
     get_stock_data,
     get_historical_prices,
@@ -25,7 +22,11 @@ from ..utils import (
     ALERT_PE_THRESHOLD,
     moving_average,
     calculate_rsi,
+    generate_xlsx,
 )
+import time
+from ..extensions import db
+from ..models import History, Alert, WatchlistItem, StockRecord
 
 main_bp = Blueprint("main", __name__)
 
@@ -483,6 +484,108 @@ def download():
             f"attachment; filename={symbol}_data.csv"
         )
         response.headers["Content-Type"] = "text/csv"
+        return response
+    elif fmt == "xlsx":
+        output = generate_xlsx(
+            [
+                "Company Name",
+                "Symbol",
+                "Price",
+                "EPS",
+                "P/E Ratio",
+                "PEG Ratio",
+                "Valuation",
+                "Market Cap",
+                "Debt/Equity",
+                "P/B",
+                "ROE %",
+                "ROA %",
+                "Profit Margin %",
+                "Analyst Rating",
+                "Dividend Yield %",
+                "Dividend Payout Ratio %",
+                "Earnings Growth %",
+                "Forward P/E",
+                "P/S Ratio",
+                "EV/EBITDA",
+                "P/FCF Ratio",
+                "Current Ratio",
+                "Sector",
+                "Industry",
+                "Exchange",
+                "Currency",
+            ],
+            [
+                company_name,
+                symbol,
+                price,
+                eps,
+                pe_ratio,
+                peg_ratio,
+                valuation,
+                market_cap,
+                debt_to_equity,
+                pb_ratio,
+                roe,
+                roa,
+                profit_margin,
+                analyst_rating,
+                dividend_yield,
+                payout_ratio,
+                earnings_growth,
+                forward_pe,
+                price_to_sales,
+                ev_to_ebitda,
+                price_to_fcf,
+                current_ratio,
+                sector,
+                industry,
+                exchange,
+                currency,
+            ],
+        )
+        response = make_response(output)
+        response.headers["Content-Disposition"] = (
+            f"attachment; filename={symbol}_data.xlsx"
+        )
+        response.headers["Content-Type"] = (
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        return response
+    elif fmt == "json":
+        data = {
+            "company_name": company_name,
+            "symbol": symbol,
+            "price": price,
+            "eps": eps,
+            "pe_ratio": pe_ratio,
+            "peg_ratio": peg_ratio,
+            "valuation": valuation,
+            "market_cap": market_cap,
+            "debt_to_equity": debt_to_equity,
+            "pb_ratio": pb_ratio,
+            "roe": roe,
+            "roa": roa,
+            "profit_margin": profit_margin,
+            "analyst_rating": analyst_rating,
+            "dividend_yield": dividend_yield,
+            "payout_ratio": payout_ratio,
+            "earnings_growth": earnings_growth,
+            "forward_pe": forward_pe,
+            "price_to_sales": price_to_sales,
+            "ev_to_ebitda": ev_to_ebitda,
+            "price_to_fcf": price_to_fcf,
+            "current_ratio": current_ratio,
+            "sector": sector,
+            "industry": industry,
+            "exchange": exchange,
+            "currency": currency,
+        }
+        response = make_response(json.dumps(data))
+        response.headers["Content-Disposition"] = (
+            f"attachment; filename={symbol}_data.json"
+        )
+        response.headers["Content-Type"] = "application/json"
         return response
     elif fmt == "pdf":
         pdf = FPDF()

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -67,6 +67,76 @@ def test_download_pdf(client, monkeypatch):
     assert resp.headers["Content-Type"] == "application/pdf"
 
 
+def test_download_xlsx(client, monkeypatch):
+    def fake_get_stock(symbol):
+        return (
+            "Test Corp",
+            "",
+            "Tech",
+            "Software",
+            "NASDAQ",
+            "USD",
+            100,
+            5,
+            "1B",
+            0.5,
+            1.1,
+            0.1,
+            0.05,
+            0.2,
+            "Buy",
+            0.03,
+            0.2,
+            0.15,
+            20,
+            5,
+            10,
+            15,
+            1.5,
+        )
+
+    monkeypatch.setattr("stockapp.main.routes.get_stock_data", fake_get_stock)
+    resp = client.get("/download?symbol=AAA&format=xlsx")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"].startswith(
+        "application/vnd.openxmlformats-officedocument"
+    )
+
+
+def test_download_json(client, monkeypatch):
+    def fake_get_stock(symbol):
+        return (
+            "Test Corp",
+            "",
+            "Tech",
+            "Software",
+            "NASDAQ",
+            "USD",
+            100,
+            5,
+            "1B",
+            0.5,
+            1.1,
+            0.1,
+            0.05,
+            0.2,
+            "Buy",
+            0.03,
+            0.2,
+            0.15,
+            20,
+            5,
+            10,
+            15,
+            1.5,
+        )
+
+    monkeypatch.setattr("stockapp.main.routes.get_stock_data", fake_get_stock)
+    resp = client.get("/download?symbol=AAA&format=json")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "application/json"
+
+
 def test_loan_calculator(client):
     data = {"loan_amount": 1000, "loan_rate": 5, "loan_years": 1}
     resp = client.post("/calc/loan", data=data)
@@ -88,3 +158,35 @@ def test_export_portfolio_csv(auth_client, app):
     assert resp.status_code == 200
     assert resp.headers["Content-Type"] == "text/csv"
     assert b"Symbol,Quantity,Price Paid" in resp.data
+
+
+def test_export_portfolio_xlsx(auth_client, app):
+    from stockapp.models import User, PortfolioItem
+    from stockapp.extensions import db
+
+    with app.app_context():
+        user = User.query.filter_by(username="tester").first()
+        db.session.add(
+            PortfolioItem(symbol="BBB", quantity=2, price_paid=20, user_id=user.id)
+        )
+        db.session.commit()
+    resp = auth_client.get("/export_portfolio?format=xlsx")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"].startswith(
+        "application/vnd.openxmlformats-officedocument"
+    )
+
+
+def test_export_portfolio_json(auth_client, app):
+    from stockapp.models import User, PortfolioItem
+    from stockapp.extensions import db
+
+    with app.app_context():
+        user = User.query.filter_by(username="tester").first()
+        db.session.add(
+            PortfolioItem(symbol="CCC", quantity=3, price_paid=30, user_id=user.id)
+        )
+        db.session.commit()
+    resp = auth_client.get("/export_portfolio?format=json")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "application/json"


### PR DESCRIPTION
## Summary
- support XLSX and JSON exports for stock data, portfolio and watch history
- implement simple XLSX generator
- document new export formats
- add tests for new export types

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686723c827008326aee284d98997d19c