### PR TITLE
Add ROI, DCF and tax calculators

### DIFF
--- a/stockapp/calculators/routes.py
+++ b/stockapp/calculators/routes.py
@@ -103,3 +103,87 @@ def loan():
         loan_result=loan_result,
         error_message=error_message,
     )
+
+
+@calc_bp.route("/roi", methods=["GET", "POST"])
+def roi():
+    initial = final = None
+    roi_result = None
+    error_message = None
+    if request.method == "POST":
+        try:
+            initial = float(request.form.get("initial", 0))
+            final = float(request.form.get("final", 0))
+            if initial != 0:
+                roi_result = round(((final - initial) / initial) * 100, 2)
+            else:
+                error_message = "Initial investment cannot be zero."
+        except ValueError:
+            error_message = "Invalid input for ROI calculator."
+    return render_template(
+        "roi.html",
+        initial=initial,
+        final=final,
+        roi_result=roi_result,
+        error_message=error_message,
+    )
+
+
+@calc_bp.route("/dcf", methods=["GET", "POST"])
+def dcf():
+    cash_flow = rate = years = terminal_value = None
+    dcf_result = None
+    error_message = None
+    if request.method == "POST":
+        try:
+            cash_flow = float(request.form.get("cash_flow", 0))
+            rate = float(request.form.get("discount_rate", 0))
+            years = int(request.form.get("years", 0))
+            terminal_value = float(request.form.get("terminal_value", 0))
+            discount = rate / 100
+            total = 0
+            for i in range(1, years + 1):
+                total += cash_flow / (1 + discount) ** i
+            total += terminal_value / (1 + discount) ** years
+            dcf_result = round(total, 2)
+        except ValueError:
+            error_message = "Invalid input for DCF calculator."
+    return render_template(
+        "dcf.html",
+        cash_flow=cash_flow,
+        discount_rate=rate,
+        years=years,
+        terminal_value=terminal_value,
+        dcf_result=dcf_result,
+        error_message=error_message,
+    )
+
+
+@calc_bp.route("/tax", methods=["GET", "POST"])
+def tax():
+    purchase_price = sale_price = quantity = tax_rate = None
+    tax_result = None
+    error_message = None
+    if request.method == "POST":
+        try:
+            purchase_price = float(request.form.get("purchase_price", 0))
+            sale_price = float(request.form.get("sale_price", 0))
+            quantity = float(request.form.get("quantity", 0))
+            tax_rate = float(request.form.get("tax_rate", 0))
+            gain = (sale_price - purchase_price) * quantity
+            tax_due = gain * (tax_rate / 100)
+            tax_result = {
+                "gain": round(gain, 2),
+                "tax_due": round(tax_due, 2),
+            }
+        except ValueError:
+            error_message = "Invalid input for tax calculator."
+    return render_template(
+        "tax.html",
+        purchase_price=purchase_price,
+        sale_price=sale_price,
+        quantity=quantity,
+        tax_rate=tax_rate,
+        tax_result=tax_result,
+        error_message=error_message,
+    )

--- a/templates/dcf.html
+++ b/templates/dcf.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} - DCF Calculator{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <h3 class="mb-4">Discounted Cash Flow</h3>
+    <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="mb-3">
+            <label for="cash_flow" class="form-label">Annual Cash Flow</label>
+            <input type="number" step="any" id="cash_flow" name="cash_flow" value="{{ cash_flow }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="discount_rate" class="form-label">Discount Rate (%)</label>
+            <input type="number" step="any" id="discount_rate" name="discount_rate" value="{{ discount_rate }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="years" class="form-label">Years</label>
+            <input type="number" id="years" name="years" value="{{ years }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="terminal_value" class="form-label">Terminal Value</label>
+            <input type="number" step="any" id="terminal_value" name="terminal_value" value="{{ terminal_value }}" class="form-control" required>
+        </div>
+        <div class="d-grid">
+            <button type="submit" class="btn btn-primary">Calculate</button>
+        </div>
+    </form>
+    {% if error_message %}
+        <div class="alert alert-danger mt-3">{{ error_message }}</div>
+    {% endif %}
+    {% if dcf_result is not none %}
+        <p class="mt-3"><strong>Present Value:</strong> {{ dcf_result }}</p>
+    {% endif %}
+    <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/templates/roi.html
+++ b/templates/roi.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} - ROI Calculator{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <h3 class="mb-4">Return on Investment</h3>
+    <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="mb-3">
+            <label for="initial" class="form-label">Initial Investment</label>
+            <input type="number" step="any" id="initial" name="initial" value="{{ initial }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="final" class="form-label">Final Value</label>
+            <input type="number" step="any" id="final" name="final" value="{{ final }}" class="form-control" required>
+        </div>
+        <div class="d-grid">
+            <button type="submit" class="btn btn-primary">Calculate</button>
+        </div>
+    </form>
+    {% if error_message %}
+        <div class="alert alert-danger mt-3">{{ error_message }}</div>
+    {% endif %}
+    {% if roi_result is not none %}
+        <p class="mt-3"><strong>ROI:</strong> {{ roi_result }}%</p>
+    {% endif %}
+    <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/templates/tax.html
+++ b/templates/tax.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} - Tax Calculator{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <h3 class="mb-4">Capital Gains Tax</h3>
+    <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="mb-3">
+            <label for="purchase_price" class="form-label">Purchase Price</label>
+            <input type="number" step="any" id="purchase_price" name="purchase_price" value="{{ purchase_price }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="sale_price" class="form-label">Sale Price</label>
+            <input type="number" step="any" id="sale_price" name="sale_price" value="{{ sale_price }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="quantity" class="form-label">Quantity</label>
+            <input type="number" step="any" id="quantity" name="quantity" value="{{ quantity }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="tax_rate" class="form-label">Tax Rate (%)</label>
+            <input type="number" step="any" id="tax_rate" name="tax_rate" value="{{ tax_rate }}" class="form-control" required>
+        </div>
+        <div class="d-grid">
+            <button type="submit" class="btn btn-primary">Calculate</button>
+        </div>
+    </form>
+    {% if error_message %}
+        <div class="alert alert-danger mt-3">{{ error_message }}</div>
+    {% endif %}
+    {% if tax_result %}
+        <p class="mt-3"><strong>Capital Gain:</strong> {{ tax_result.gain }}</p>
+        <p><strong>Tax Due:</strong> {{ tax_result.tax_due }}</p>
+    {% endif %}
+    <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -190,3 +190,34 @@ def test_export_portfolio_json(auth_client, app):
     resp = auth_client.get("/export_portfolio?format=json")
     assert resp.status_code == 200
     assert resp.headers["Content-Type"] == "application/json"
+
+
+def test_roi_calculator(client):
+    data = {"initial": 100, "final": 120}
+    resp = client.post("/calc/roi", data=data)
+    assert resp.status_code == 200
+    assert b"ROI:" in resp.data
+
+
+def test_dcf_calculator(client):
+    data = {
+        "cash_flow": 100,
+        "discount_rate": 10,
+        "years": 2,
+        "terminal_value": 50,
+    }
+    resp = client.post("/calc/dcf", data=data)
+    assert resp.status_code == 200
+    assert b"Present Value" in resp.data
+
+
+def test_tax_calculator(client):
+    data = {
+        "purchase_price": 10,
+        "sale_price": 15,
+        "quantity": 2,
+        "tax_rate": 20,
+    }
+    resp = client.post("/calc/tax", data=data)
+    assert resp.status_code == 200
+    assert b"Tax Due" in resp.data


### PR DESCRIPTION
## Summary
- extend calculators blueprint with ROI, DCF and tax routes
- create templates for ROI, DCF and tax
- test new calculator routes

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686760f2021c83268c5ce21e3ff326af