### PR TITLE
Add Flask-Babel localization support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ app.db
 .DS_Store
 *.swp
 node_modules/
+
+# Translations
+translations/**/LC_MESSAGES/*.mo

--- a/README.md
+++ b/README.md
@@ -224,3 +224,10 @@ npm run build
 This populates the `static/vendor/` directory so the service worker can cache
 the assets even when offline.
 
+## Localization
+
+User language preferences are now respected using **Flask-Babel**. Set the
+desired language from the Settings page. Translations live in the `translations/`
+folder. Only the `.po` files are tracked in git. After editing them run
+`pybabel compile -d translations` to generate the binary `.mo` files locally.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ fpdf
 Flask-Login
 Flask-SQLAlchemy
 Flask-WTF
+Flask-Babel
 celery
 pyotp
 plotly

--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -1,7 +1,7 @@
 import os
 from flask import Flask
 from werkzeug.security import generate_password_hash
-from .extensions import db, login_manager, csrf, sock
+from .extensions import db, login_manager, csrf, sock, babel
 from .models import User
 from .auth import auth_bp
 from .main import main_bp
@@ -39,6 +39,13 @@ def create_app(config_class=None):
     login_manager.login_view = "auth.login"
     csrf.init_app(app)
     sock.init_app(app)
+    babel.init_app(app)
+
+    from .utils import get_locale
+
+    @babel.localeselector
+    def locale_selector():
+        return get_locale()
 
     @app.context_processor
     def inject_globals():

--- a/stockapp/config.py
+++ b/stockapp/config.py
@@ -26,6 +26,9 @@ class Config:
     TWILIO_TOKEN = ""
     TWILIO_FROM = ""
 
+    BABEL_DEFAULT_LOCALE = "en"
+    BABEL_TRANSLATION_DIRECTORIES = "translations"
+
     DEBUG = False
 
     def __init__(self):

--- a/stockapp/extensions.py
+++ b/stockapp/extensions.py
@@ -3,6 +3,23 @@ from flask_login import LoginManager
 from flask_wtf import CSRFProtect
 from flask_sock import Sock
 
+try:
+    from flask_babel import Babel
+except Exception:  # pragma: no cover - optional dependency
+
+    class Babel:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def init_app(self, app):
+            app.jinja_env.globals.setdefault("_", lambda s: s)
+
+        def localeselector(self, func):
+            return func
+
+
+babel = Babel()
+
 # Initialize extensions without app, will be configured in create_app
 
 db = SQLAlchemy()

--- a/stockapp/utils.py
+++ b/stockapp/utils.py
@@ -121,12 +121,12 @@ def get_locale():
     if has_request_context():
         if current_user.is_authenticated and current_user.language:
             return current_user.language
-        loc = request.accept_languages.best or "en_US"
+        loc = request.accept_languages.best or "en"
         try:
-            return str(Locale.parse(loc))
-        except Exception:
-            return "en_US"
-    return "en_US"
+            return Locale.parse(loc).language
+        except Exception:  # pragma: no cover - fallback
+            return "en"
+    return "en"
 
 
 def send_email(to, subject, body):

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,22 +21,22 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 {% if current_user.is_authenticated %}
-                    <span class="navbar-text me-2">Logged in as {{ current_user.username }}</span>
+                    <span class="navbar-text me-2">{{ _('Logged in as') }} {{ current_user.username }}</span>
                     <div class="ms-auto d-lg-flex align-items-center">
-                        <a href="{{ url_for('watch.watchlist') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">Watchlist</a>
-                        <a href="{{ url_for('watch.favorites') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">Favorites</a>
-                        <a href="{{ url_for('portfolio.portfolio') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">Portfolio</a>
-                        <a href="{{ url_for('alerts.alerts') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">Alerts</a>
-                        <a href="{{ url_for('watch.records') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">Records</a>
-                        <a href="{{ url_for('watch.export_history') }}" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">Export History</a>
-                        <a href="{{ url_for('calc.interest') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">Calculators</a>
-                        <a href="{{ url_for('watch.settings') }}" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">Settings</a>
-                        <a href="{{ url_for('auth.logout') }}" class="btn btn-sm btn-danger">Logout</a>
+                        <a href="{{ url_for('watch.watchlist') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Watchlist') }}</a>
+                        <a href="{{ url_for('watch.favorites') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Favorites') }}</a>
+                        <a href="{{ url_for('portfolio.portfolio') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Portfolio') }}</a>
+                        <a href="{{ url_for('alerts.alerts') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Alerts') }}</a>
+                        <a href="{{ url_for('watch.records') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Records') }}</a>
+                        <a href="{{ url_for('watch.export_history') }}" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">{{ _('Export History') }}</a>
+                        <a href="{{ url_for('calc.interest') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Calculators') }}</a>
+                        <a href="{{ url_for('watch.settings') }}" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">{{ _('Settings') }}</a>
+                        <a href="{{ url_for('auth.logout') }}" class="btn btn-sm btn-danger">{{ _('Logout') }}</a>
                     </div>
                 {% else %}
                     <div class="ms-auto d-lg-flex align-items-center">
-                        <a href="{{ url_for('auth.login') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">Login</a>
-                        <a href="{{ url_for('auth.signup') }}" class="btn btn-sm btn-outline-secondary mb-2 mb-lg-0">Sign Up</a>
+                        <a href="{{ url_for('auth.login') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Login') }}</a>
+                        <a href="{{ url_for('auth.signup') }}" class="btn btn-sm btn-outline-secondary mb-2 mb-lg-0">{{ _('Sign Up') }}</a>
                     </div>
                 {% endif %}
             </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ app_name }} - Login{% endblock %}
+{% block title %}{{ app_name }} - {{ _('Login') }}{% endblock %}
 
 {% block content %}
     <div class="container py-5">
@@ -8,7 +8,7 @@
             <div class="col-md-4 col-sm-12">
                 <div class="card shadow-sm">
                     <div class="card-body">
-                        <h3 class="card-title text-center mb-4">Login</h3>
+                        <h3 class="card-title text-center mb-4">{{ _('Login') }}</h3>
                         {% if error %}
                         <div class="alert alert-danger">{{ error }}</div>
                         {% endif %}
@@ -26,12 +26,12 @@
                                 {{ form.password(class="form-control") }}
                             </div>
                             <div class="d-grid">
-                                <button type="submit" class="btn btn-primary">Login</button>
+                                <button type="submit" class="btn btn-primary">{{ _('Login') }}</button>
                             </div>
                         </form>
                         <div class="mt-3 text-center">
-                            <a href="{{ url_for('auth.signup') }}">Sign Up</a> |
-                            <a href="{{ url_for('auth.forgot_password') }}">Forgot Password?</a>
+                            <a href="{{ url_for('auth.signup') }}">{{ _('Sign Up') }}</a> |
+                            <a href="{{ url_for('auth.forgot_password') }}">{{ _('Forgot Password?') }}</a>
                         </div>
                     </div>
                 </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,45 +1,45 @@
 {% extends "base.html" %}
 
-{% block title %}{{ app_name }} - Alert Settings{% endblock %}
+{% block title %}{{ app_name }} - {{ _('Alert Settings') }}{% endblock %}
 
 {% block content %}
     <div class="container py-5">
-        <h3 class="mb-4">Alert Settings</h3>
+        <h3 class="mb-4">{{ _('Alert Settings') }}</h3>
         <form method="POST" class="mb-3" style="max-width:300px;">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <label class="form-label">Alert Frequency (hours)</label>
+            <label class="form-label">{{ _('Alert Frequency (hours)') }}</label>
             <input type="number" name="frequency" min="1" class="form-control" value="{{ frequency }}" required>
-            <label class="form-label mt-3">Phone Number</label>
+            <label class="form-label mt-3">{{ _('Phone Number') }}</label>
             <input type="text" name="phone" class="form-control" value="{{ phone }}">
             <div class="form-check mt-2">
                 <input class="form-check-input" type="checkbox" name="sms_opt_in" id="sms_opt_in" {% if sms_opt_in %}checked{% endif %}>
-                <label class="form-check-label" for="sms_opt_in">Enable SMS Alerts</label>
+                <label class="form-check-label" for="sms_opt_in">{{ _('Enable SMS Alerts') }}</label>
             </div>
             <div class="form-check mt-2">
                 <input class="form-check-input" type="checkbox" name="trend_opt_in" id="trend_opt_in" {% if trend_opt_in %}checked{% endif %}>
-                <label class="form-check-label" for="trend_opt_in">Email Weekly Summary</label>
+                <label class="form-check-label" for="trend_opt_in">{{ _('Email Weekly Summary') }}</label>
             </div>
-            <label class="form-label mt-3">Default Currency</label>
+            <label class="form-label mt-3">{{ _('Default Currency') }}</label>
             <select name="currency" class="form-select">
                 {% for cur in ['USD','EUR','GBP','AUD','JPY'] %}
                     <option value="{{ cur }}" {% if currency==cur %}selected{% endif %}>{{ cur }}</option>
                 {% endfor %}
             </select>
-            <label class="form-label mt-3">Language</label>
+            <label class="form-label mt-3">{{ _('Language') }}</label>
             <select name="language" class="form-select">
                 {% for lang in ['en','es','fr','de'] %}
                     <option value="{{ lang }}" {% if language==lang %}selected{% endif %}>{{ lang }}</option>
                 {% endfor %}
             </select>
-            <label class="form-label mt-3">Theme</label>
+            <label class="form-label mt-3">{{ _('Theme') }}</label>
             <select name="theme" class="form-select">
                 <option value="light" {% if theme=='light' %}selected{% endif %}>Light</option>
                 <option value="dark" {% if theme=='dark' %}selected{% endif %}>Dark</option>
             </select>
-            <label class="form-label mt-3">Brokerage API Token</label>
+            <label class="form-label mt-3">{{ _('Brokerage API Token') }}</label>
             <input type="text" name="brokerage_token" class="form-control" value="{{ brokerage_token }}">
-            <button class="btn btn-primary mt-3" type="submit">Save</button>
+            <button class="btn btn-primary mt-3" type="submit">{{ _('Save') }}</button>
         </form>
-        <a href="{{ url_for('main.index') }}" class="btn btn-secondary">Back</a>
+        <a href="{{ url_for('main.index') }}" class="btn btn-secondary">{{ _('Back') }}</a>
     </div>
 {% endblock %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ app_name }} - Sign Up{% endblock %}
+{% block title %}{{ app_name }} - {{ _('Sign Up') }}{% endblock %}
 
 {% block content %}
     <div class="container py-5">
@@ -8,7 +8,7 @@
             <div class="col-md-4 col-sm-12">
                 <div class="card shadow-sm">
                     <div class="card-body">
-                        <h3 class="card-title text-center mb-4">Sign Up</h3>
+                        <h3 class="card-title text-center mb-4">{{ _('Sign Up') }}</h3>
                         {% if error %}
                         <div class="alert alert-danger">{{ error }}</div>
                         {% endif %}
@@ -38,11 +38,11 @@
                                 {{ form.password(class="form-control") }}
                             </div>
                             <div class="d-grid">
-                                <button type="submit" class="btn btn-primary">Sign Up</button>
+                                <button type="submit" class="btn btn-primary">{{ _('Sign Up') }}</button>
                             </div>
                         </form>
                         <div class="mt-3 text-center">
-                            <a href="{{ url_for('auth.login') }}">Login</a>
+                            <a href="{{ url_for('auth.login') }}">{{ _('Login') }}</a>
                         </div>
                     </div>
                 </div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -84,3 +84,16 @@ def test_ws_price_route(app):
     with app.test_request_context():
         url = url_for("main.ws_price")
     assert url == "/ws/price"
+
+
+def test_localization_es(auth_client, app):
+    from stockapp.extensions import db
+    from stockapp.models import User
+
+    with app.app_context():
+        user = User.query.filter_by(username="tester").first()
+        user.language = "es"
+        db.session.commit()
+
+    resp = auth_client.get("/settings")
+    assert b"Configuraci\xc3\xb3n de alertas" in resp.data

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -1,0 +1,76 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\n"
+"Language: es\n"
+
+msgid "Login"
+msgstr "Iniciar sesión"
+
+msgid "Logout"
+msgstr "Cerrar sesión"
+
+msgid "Sign Up"
+msgstr "Registrarse"
+
+msgid "Settings"
+msgstr "Configuración"
+
+msgid "Watchlist"
+msgstr "Lista de seguimiento"
+
+msgid "Favorites"
+msgstr "Favoritos"
+
+msgid "Portfolio"
+msgstr "Portafolio"
+
+msgid "Alerts"
+msgstr "Alertas"
+
+msgid "Records"
+msgstr "Registros"
+
+msgid "Export History"
+msgstr "Exportar historial"
+
+msgid "Calculators"
+msgstr "Calculadoras"
+
+msgid "Alert Settings"
+msgstr "Configuración de alertas"
+
+msgid "Alert Frequency (hours)"
+msgstr "Frecuencia de alertas (horas)"
+
+msgid "Phone Number"
+msgstr "Número de teléfono"
+
+msgid "Enable SMS Alerts"
+msgstr "Habilitar alertas SMS"
+
+msgid "Email Weekly Summary"
+msgstr "Resumen semanal por correo"
+
+msgid "Default Currency"
+msgstr "Moneda predeterminada"
+
+msgid "Language"
+msgstr "Idioma"
+
+msgid "Theme"
+msgstr "Tema"
+
+msgid "Brokerage API Token"
+msgstr "Token de API de broker"
+
+msgid "Save"
+msgstr "Guardar"
+
+msgid "Back"
+msgstr "Volver"
+
+msgid "Logged in as"
+msgstr "Conectado como"
+
+msgid "Forgot Password?"
+msgstr "¿Olvidaste tu contraseña?"


### PR DESCRIPTION
## Summary
- add Flask-Babel dependency and configuration
- provide Spanish translations
- wire Babel into application factory with fallback when dependency missing
- update base, login, signup and settings templates to use gettext
- document localization support
- test that Spanish translation is applied when user sets language to es
- remove compiled MO files from version control

## Testing
- `black . --check`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_6867657061288326b2dae5e2b3161bc5