### PR TITLE
Add brokerage transaction syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ import a file to quickly populate your portfolio. The CSV format uses the
 columns `Symbol`, `Quantity` and `Price Paid`.
 
 * **Portfolio Diversification Analyzer** – automatically analyzes sector allocations, asset correlations and overall portfolio volatility to highlight concentration risk. Enhanced metrics like Beta, Sharpe ratio and Value at Risk provide deeper risk insights.
+* **Brokerage Transaction Sync** – portfolio holdings and recent transactions can now be synchronized from connected brokerage accounts using the new stub API.
 
 ## Finance Calculators
 

--- a/stockapp/brokerage.py
+++ b/stockapp/brokerage.py
@@ -28,3 +28,33 @@ def get_holdings(api_token: str) -> List[Dict[str, float]]:
             {"symbol": "BBB", "quantity": 1, "price_paid": 110},
         ]
     return []
+
+
+def get_transactions(api_token: str) -> List[Dict[str, object]]:
+    """Return a list of recent transactions for the given API token.
+
+    In production this would contact the brokerage REST API. For the test
+    environment we simply return a fixed set of transactions when the special
+    ``demo-token`` is used.
+
+    Each transaction dictionary contains ``symbol``, ``quantity``, ``price``,
+    ``type`` and ``timestamp`` keys.
+    """
+    if api_token == "demo-token":
+        return [
+            {
+                "symbol": "AAA",
+                "quantity": 1,
+                "price": 95,
+                "type": "BUY",
+                "timestamp": "2023-01-01",
+            },
+            {
+                "symbol": "BBB",
+                "quantity": 1,
+                "price": 120,
+                "type": "BUY",
+                "timestamp": "2023-01-02",
+            },
+        ]
+    return []

--- a/stockapp/models.py
+++ b/stockapp/models.py
@@ -82,6 +82,16 @@ class PortfolioItem(db.Model):
     tags = db.Column(db.String(100))
 
 
+class Transaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    symbol = db.Column(db.String(10), nullable=False)
+    quantity = db.Column(db.Float, nullable=False)
+    price = db.Column(db.Float, nullable=False)
+    txn_type = db.Column(db.String(4), nullable=False)  # BUY or SELL
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+
+
 class PortfolioFollow(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     follower_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)

--- a/stockapp/tasks.py
+++ b/stockapp/tasks.py
@@ -14,7 +14,10 @@ from .utils import (
     send_sms,
     ALERT_PE_THRESHOLD,
 )
-from .portfolio.helpers import sync_portfolio_from_brokerage
+from .portfolio.helpers import (
+    sync_portfolio_from_brokerage,
+    sync_transactions_from_brokerage,
+)
 
 # Celery application instance configured in ``init_celery``.
 celery = Celery(__name__)
@@ -167,6 +170,7 @@ def _sync_brokerage():
     users = User.query.filter(User.brokerage_token.isnot(None)).all()
     for user in users:
         sync_portfolio_from_brokerage(user.id, user.brokerage_token)
+        sync_transactions_from_brokerage(user.id, user.brokerage_token)
 
 
 @celery.task(name="stockapp.tasks.sync_brokerage_task")

--- a/tests/test_brokerage.py
+++ b/tests/test_brokerage.py
@@ -1,0 +1,16 @@
+import pytest
+
+from stockapp.portfolio.helpers import sync_transactions_from_brokerage
+from stockapp.models import User, PortfolioItem, Transaction
+from stockapp.extensions import db
+
+
+def test_sync_transactions(app):
+    with app.app_context():
+        user = User.query.filter_by(username="tester").first()
+        sync_transactions_from_brokerage(user.id, "demo-token")
+        txns = Transaction.query.filter_by(user_id=user.id).all()
+        assert len(txns) == 2
+        items = {i.symbol: i for i in PortfolioItem.query.filter_by(user_id=user.id).all()}
+        assert "AAA" in items
+        assert items["AAA"].quantity >= 1


### PR DESCRIPTION
## Summary
- expand brokerage client with `get_transactions`
- add `Transaction` model
- support syncing transactions from brokerage and updating portfolio holdings
- call transaction sync from scheduled Celery task
- document brokerage sync
- cover new functionality with a test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68676812cc7883269de22f72722a8ef9