### PR TITLE
Implement portfolio leaderboard feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ columns `Symbol`, `Quantity` and `Price Paid`.
 * **Portfolio Diversification Analyzer** – automatically analyzes sector allocations, asset correlations and overall portfolio volatility to highlight concentration risk. Enhanced metrics like Beta, Sharpe ratio and Value at Risk provide deeper risk insights.
 * **Brokerage Transaction Sync** – portfolio holdings and recent transactions can now be synchronized from connected brokerage accounts using the new stub API.
 
+## Social Features
+
+Public watchlists let you share ideas with other traders. Visit `/watchlist/public/<username>` to see another user's list. You can also follow portfolios you find interesting. Check out the **Leaderboard** link in the navigation bar to see which users have the most followers.
+
 ## Finance Calculators
 
 Several quick calculators are available at their own routes:

--- a/stockapp/portfolio/routes.py
+++ b/stockapp/portfolio/routes.py
@@ -164,3 +164,19 @@ def follow_portfolio(username):
         )
     db.session.commit()
     return redirect(url_for("portfolio.view_portfolio", username=username))
+
+
+@portfolio_bp.route("/leaderboard")
+def leaderboard():
+    from sqlalchemy import func
+
+    results = (
+        db.session.query(User.username, func.count(PortfolioFollow.id).label("count"))
+        .outerjoin(PortfolioFollow, User.id == PortfolioFollow.followed_id)
+        .group_by(User.id)
+        .order_by(func.count(PortfolioFollow.id).desc())
+        .limit(10)
+        .all()
+    )
+    return render_template("leaderboard.html", leaders=results)
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,7 @@
                         <a href="{{ url_for('watch.watchlist') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Watchlist') }}</a>
                         <a href="{{ url_for('watch.favorites') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Favorites') }}</a>
                         <a href="{{ url_for('portfolio.portfolio') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Portfolio') }}</a>
+                        <a href="{{ url_for('portfolio.leaderboard') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Leaderboard') }}</a>
                         <a href="{{ url_for('alerts.alerts') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Alerts') }}</a>
                         <a href="{{ url_for('watch.records') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Records') }}</a>
                         <a href="{{ url_for('watch.export_history') }}" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">{{ _('Export History') }}</a>
@@ -35,6 +36,7 @@
                     </div>
                 {% else %}
                     <div class="ms-auto d-lg-flex align-items-center">
+                        <a href="{{ url_for('portfolio.leaderboard') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Leaderboard') }}</a>
                         <a href="{{ url_for('auth.login') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Login') }}</a>
                         <a href="{{ url_for('auth.signup') }}" class="btn btn-sm btn-outline-secondary mb-2 mb-lg-0">{{ _('Sign Up') }}</a>
                     </div>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Leaderboard{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h3 class="mb-4">Top Followed Portfolios</h3>
+  {% if leaders %}
+  <ul class="list-group">
+    {% for username, count in leaders %}
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      <a href="{{ url_for('portfolio.view_portfolio', username=username) }}">{{ username }}</a>
+      <span class="badge bg-primary rounded-pill">{{ count }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>No data.</p>
+  {% endif %}
+  <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}
+

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -360,3 +360,28 @@ def test_public_watchlist_and_follow_portfolio(app, client, auth_client):
     auth_client.get("/portfolio/follow/other", follow_redirects=True)
     resp = auth_client.get("/portfolio/other", follow_redirects=True)
     assert b"SOC" in resp.data
+
+
+def test_leaderboard(app, client):
+    from stockapp.extensions import db
+    from stockapp.models import User, PortfolioFollow
+    from werkzeug.security import generate_password_hash
+
+    with app.app_context():
+        u1 = User(username="l1", email="l1@e.com", password_hash=generate_password_hash("x"), is_verified=True)
+        u2 = User(username="l2", email="l2@e.com", password_hash=generate_password_hash("x"), is_verified=True)
+        u3 = User(username="l3", email="l3@e.com", password_hash=generate_password_hash("x"), is_verified=True)
+        db.session.add_all([u1, u2, u3])
+        db.session.commit()
+        db.session.add_all([
+            PortfolioFollow(follower_id=u2.id, followed_id=u1.id),
+            PortfolioFollow(follower_id=u3.id, followed_id=u1.id),
+            PortfolioFollow(follower_id=u3.id, followed_id=u2.id),
+        ])
+        db.session.commit()
+
+    resp = client.get("/leaderboard")
+    assert resp.status_code == 200
+    data = resp.data.decode()
+    assert "l1" in data and "l2" in data
+


### PR DESCRIPTION
## Summary
- add a leaderboard page to rank portfolios by followers
- expose leaderboard link in navbar
- document social features
- test leaderboard route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686769e60100832698d36080101f5de7