### PR TITLE
Add WACC calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Several quick calculators are available at their own routes:
 * `/calc/interest` – simple interest
 * `/calc/compound` – compound interest
 * `/calc/loan` – **Loan/Mortgage payment** – computes monthly payment, total interest and shows a full amortization schedule.
+* `/calc/wacc` – Weighted Average Cost of Capital
 
 ## Viewing Alerts
 

--- a/stockapp/calculators/routes.py
+++ b/stockapp/calculators/routes.py
@@ -187,3 +187,39 @@ def tax():
         tax_result=tax_result,
         error_message=error_message,
     )
+
+
+@calc_bp.route("/wacc", methods=["GET", "POST"])
+def wacc():
+    """Weighted Average Cost of Capital calculator."""
+    equity = debt = cost_equity = cost_debt = tax_rate = None
+    wacc_result = None
+    error_message = None
+    if request.method == "POST":
+        try:
+            equity = float(request.form.get("equity", 0))
+            debt = float(request.form.get("debt", 0))
+            cost_equity = float(request.form.get("cost_equity", 0))
+            cost_debt = float(request.form.get("cost_debt", 0))
+            tax_rate = float(request.form.get("tax_rate", 0))
+            total = equity + debt
+            if total > 0:
+                wacc_result = round(
+                    (equity / total) * cost_equity
+                    + (debt / total) * cost_debt * (1 - tax_rate / 100),
+                    2,
+                )
+            else:
+                error_message = "Equity and debt cannot both be zero."
+        except ValueError:
+            error_message = "Invalid input for WACC calculator."
+    return render_template(
+        "wacc.html",
+        equity=equity,
+        debt=debt,
+        cost_equity=cost_equity,
+        cost_debt=cost_debt,
+        tax_rate=tax_rate,
+        wacc_result=wacc_result,
+        error_message=error_message,
+    )

--- a/templates/wacc.html
+++ b/templates/wacc.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}{{ app_name }} - WACC Calculator{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <h3 class="mb-4">Weighted Average Cost of Capital</h3>
+    <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="mb-3">
+            <label for="equity" class="form-label">Equity Value</label>
+            <input type="number" step="any" id="equity" name="equity" value="{{ equity }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="debt" class="form-label">Debt Value</label>
+            <input type="number" step="any" id="debt" name="debt" value="{{ debt }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="cost_equity" class="form-label">Cost of Equity (%)</label>
+            <input type="number" step="any" id="cost_equity" name="cost_equity" value="{{ cost_equity }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="cost_debt" class="form-label">Cost of Debt (%)</label>
+            <input type="number" step="any" id="cost_debt" name="cost_debt" value="{{ cost_debt }}" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="tax_rate" class="form-label">Tax Rate (%)</label>
+            <input type="number" step="any" id="tax_rate" name="tax_rate" value="{{ tax_rate }}" class="form-control" required>
+        </div>
+        <div class="d-grid">
+            <button type="submit" class="btn btn-primary">Calculate</button>
+        </div>
+    </form>
+    {% if error_message %}
+        <div class="alert alert-danger mt-3">{{ error_message }}</div>
+    {% endif %}
+    {% if wacc_result is not none %}
+        <p class="mt-3"><strong>WACC:</strong> {{ wacc_result }}%</p>
+    {% endif %}
+    <a href="{{ url_for('main.index') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -221,3 +221,16 @@ def test_tax_calculator(client):
     resp = client.post("/calc/tax", data=data)
     assert resp.status_code == 200
     assert b"Tax Due" in resp.data
+
+
+def test_wacc_calculator(client):
+    data = {
+        "equity": 1000,
+        "debt": 500,
+        "cost_equity": 10,
+        "cost_debt": 5,
+        "tax_rate": 20,
+    }
+    resp = client.post("/calc/wacc", data=data)
+    assert resp.status_code == 200
+    assert b"WACC:" in resp.data


### PR DESCRIPTION
## Summary
- add Weighted Average Cost of Capital calculator route
- create WACC form template
- document WACC calculator
- test new calculator functionality

## Testing
- `black . --check`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6868e2e04cdc83269d2f9cae94b01a49