### PR TITLE
Improve watchlist sorting

### DIFF
--- a/stockapp/watchlists/routes.py
+++ b/stockapp/watchlists/routes.py
@@ -78,7 +78,11 @@ def watchlist():
                         )
                     )
                     db.session.commit()
-    items = WatchlistItem.query.filter_by(user_id=current_user.id).all()
+    items = (
+        WatchlistItem.query.filter_by(user_id=current_user.id)
+        .order_by(WatchlistItem.symbol)
+        .all()
+    )
     news = {i.symbol: get_stock_news(i.symbol, limit=3) for i in items}
     return render_template(
         "watchlist.html",


### PR DESCRIPTION
## Summary
- sort watchlist entries alphabetically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686a1d4fb6508326a9d2496052580c28