### PR TITLE
Add web push alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ ticker, the browser opens `ws://host/ws/price`, sends the symbol and receives
 periodic JSON messages containing the latest price and EPS. This enables future
 bidirectional features like push alerts.
 
+### Push Notifications
+
+If VAPID keys are configured, browsers can subscribe to push alerts. When
+watchlist thresholds are crossed the server sends a Web Push message that is
+displayed via the service worker even if the page is not focused.
+
 ### Frontend Assets
 
 Bootstrap and Plotly are now managed locally instead of pulled from a CDN. A

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ pytest
 redis
 python-dotenv
 flask-sock
+pywebpush
 
 black
 flake8

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -32,3 +32,13 @@ self.addEventListener('fetch', event => {
       .then(response => response || fetch(event.request))
   );
 });
+
+self.addEventListener('push', event => {
+  let data = {};
+  if (event.data) {
+    try { data = event.data.json(); } catch (e) { data = {body: event.data.text()}; }
+  }
+  const title = data.title || 'MarketMinder Alert';
+  const options = { body: data.body, icon: '/static/icons/icon-192.png' };
+  event.waitUntil(self.registration.showNotification(title, options));
+});

--- a/stockapp/alerts/routes.py
+++ b/stockapp/alerts/routes.py
@@ -1,8 +1,9 @@
-from flask import Blueprint, render_template, redirect, url_for
+from flask import Blueprint, render_template, redirect, url_for, request
 from flask_login import login_required, current_user
 
 from ..extensions import db
-from ..models import Alert
+from ..models import Alert, PushSubscription
+from ..utils import notify_user_push
 
 alerts_bp = Blueprint("alerts", __name__)
 
@@ -24,3 +25,36 @@ def clear_alerts():
     Alert.query.filter_by(user_id=current_user.id).delete()
     db.session.commit()
     return redirect(url_for("alerts.alerts"))
+
+
+@alerts_bp.route("/subscribe_push", methods=["POST"])
+@login_required
+def subscribe_push():
+    data = request.get_json() or {}
+    if not data.get("endpoint"):
+        return "", 400
+    sub = PushSubscription.query.filter_by(
+        user_id=current_user.id, endpoint=data.get("endpoint")
+    ).first()
+    if not sub:
+        db.session.add(
+            PushSubscription(
+                endpoint=data["endpoint"],
+                p256dh=data.get("keys", {}).get("p256dh"),
+                auth=data.get("keys", {}).get("auth"),
+                user_id=current_user.id,
+            )
+        )
+        db.session.commit()
+    return "", 204
+
+
+@alerts_bp.route("/unsubscribe_push", methods=["POST"])
+@login_required
+def unsubscribe_push():
+    data = request.get_json() or {}
+    PushSubscription.query.filter_by(
+        user_id=current_user.id, endpoint=data.get("endpoint")
+    ).delete()
+    db.session.commit()
+    return "", 204

--- a/stockapp/config.py
+++ b/stockapp/config.py
@@ -26,6 +26,9 @@ class Config:
     TWILIO_TOKEN = ""
     TWILIO_FROM = ""
 
+    VAPID_PUBLIC_KEY = ""
+    VAPID_PRIVATE_KEY = ""
+
     BABEL_DEFAULT_LOCALE = "en"
     BABEL_TRANSLATION_DIRECTORIES = "translations"
 
@@ -50,6 +53,8 @@ class Config:
         self.TWILIO_SID = os.environ.get("TWILIO_SID", self.TWILIO_SID)
         self.TWILIO_TOKEN = os.environ.get("TWILIO_TOKEN", self.TWILIO_TOKEN)
         self.TWILIO_FROM = os.environ.get("TWILIO_FROM", self.TWILIO_FROM)
+        self.VAPID_PUBLIC_KEY = os.environ.get("VAPID_PUBLIC_KEY", self.VAPID_PUBLIC_KEY)
+        self.VAPID_PRIVATE_KEY = os.environ.get("VAPID_PRIVATE_KEY", self.VAPID_PRIVATE_KEY)
 
 
 class DevelopmentConfig(Config):

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -25,6 +25,7 @@ from ..utils import (
     calculate_macd,
     bollinger_bands,
     generate_xlsx,
+    notify_user_push,
 )
 import time
 from ..extensions import db, sock
@@ -235,6 +236,7 @@ def index():
                             )
                         )
                         db.session.commit()
+                        notify_user_push(current_user.id, alert_message)
                 elif (
                     de_thr is not None
                     and debt_to_equity is not None
@@ -250,6 +252,7 @@ def index():
                             )
                         )
                         db.session.commit()
+                        notify_user_push(current_user.id, alert_message)
                 elif rsi_thr is not None or ma_thr is not None:
                     if history_prices:
                         if rsi_thr is not None:
@@ -281,6 +284,7 @@ def index():
                                 )
                             )
                             db.session.commit()
+                            notify_user_push(current_user.id, alert_message)
             elif price is None or eps is None:
                 error_message = "Price or EPS data is missing."
             if debt_to_equity is not None:

--- a/stockapp/models.py
+++ b/stockapp/models.py
@@ -55,6 +55,14 @@ class Alert(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
 
 
+class PushSubscription(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    endpoint = db.Column(db.String(200))
+    p256dh = db.Column(db.String(200))
+    auth = db.Column(db.String(200))
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+
+
 class History(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     symbol = db.Column(db.String(10))

--- a/stockapp/tasks.py
+++ b/stockapp/tasks.py
@@ -12,6 +12,7 @@ from .utils import (
     calculate_rsi,
     send_email,
     send_sms,
+    notify_user_push,
     ALERT_PE_THRESHOLD,
 )
 from .portfolio.helpers import (
@@ -119,6 +120,7 @@ def _check_watchlists():
                 if user.sms_opt_in and user.phone_number:
                     send_sms(user.phone_number, msg)
                 db.session.add(Alert(symbol=item.symbol, message=msg, user_id=user.id))
+                notify_user_push(user.id, msg)
         user.last_alert_time = now
     db.session.commit()
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,9 +48,31 @@
     <script src="{{ url_for('static', filename='vendor/bootstrap.bundle.min.js') }}"></script>
     {% block scripts %}{% endblock %}
     <script>
-        if ('serviceWorker' in navigator) {
-            window.addEventListener('load', function() {
-                navigator.serviceWorker.register('/service-worker.js');
+        if ('serviceWorker' in navigator && 'PushManager' in window) {
+            window.addEventListener('load', function () {
+                navigator.serviceWorker.register('/service-worker.js').then(reg => {
+                    function subscribe() {
+                        const key = '{{ current_app.config.get("VAPID_PUBLIC_KEY", "") }}';
+                        if (!key) return;
+                        reg.pushManager.getSubscription().then(sub => {
+                            if (!sub) {
+                                reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: key })
+                                    .then(s => {
+                                        fetch('{{ url_for("alerts.subscribe_push") }}', {
+                                            method: 'POST',
+                                            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': '{{ csrf_token() }}' },
+                                            body: JSON.stringify(s)
+                                        });
+                                    });
+                            }
+                        });
+                    }
+                    if (Notification.permission === 'granted') {
+                        subscribe();
+                    } else if (Notification.permission === 'default') {
+                        Notification.requestPermission().then(p => { if (p === 'granted') subscribe(); });
+                    }
+                });
             });
         }
     </script>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -95,6 +95,14 @@ def test_ws_price_route(app):
     assert url == "/ws/price"
 
 
+def test_push_subscribe(auth_client):
+    resp = auth_client.post(
+        "/subscribe_push",
+        json={"endpoint": "e", "keys": {"p256dh": "a", "auth": "b"}},
+    )
+    assert resp.status_code == 204
+
+
 def test_localization_es(auth_client, app):
     from stockapp.extensions import db
     from stockapp.models import User


### PR DESCRIPTION
## Summary
- add pywebpush dependency
- store VAPID keys in config
- handle user push subscriptions
- send notifications from tasks and index alerts
- include PushSubscription model and utility helpers
- register push in service worker and base template
- document push notification support
- test push subscribe route

## Testing
- `pip install -q -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686a2d71b0048326b8294cc8d9952f63