### PR TITLE
Add multi-currency conversion

### DIFF
--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -26,6 +26,7 @@ from ..utils import (
     bollinger_bands,
     generate_xlsx,
     notify_user_push,
+    convert_currency,
 )
 import time
 from ..extensions import db, sock
@@ -175,8 +176,14 @@ def index():
                 current_ratio,
             ) = get_stock_data(symbol)
 
+            target_currency = currency
             if current_user.is_authenticated and current_user.default_currency:
-                currency = current_user.default_currency
+                target_currency = current_user.default_currency
+            if price is not None and currency != target_currency:
+                price = convert_currency(price, currency, target_currency)
+            if eps is not None and currency != target_currency:
+                eps = convert_currency(eps, currency, target_currency)
+            currency = target_currency
 
             history_dates, history_prices = get_historical_prices(symbol, days=90)
             ma20 = moving_average(history_prices, 20)
@@ -447,8 +454,14 @@ def download():
         current_ratio,
     ) = get_stock_data(symbol)
 
+    target_currency = currency
     if current_user.is_authenticated and current_user.default_currency:
-        currency = current_user.default_currency
+        target_currency = current_user.default_currency
+    if price is not None and currency != target_currency:
+        price = convert_currency(price, currency, target_currency)
+    if eps is not None and currency != target_currency:
+        eps = convert_currency(eps, currency, target_currency)
+    currency = target_currency
 
     if price is not None and eps:
         pe_ratio_val = round(price / eps, 2)

--- a/stockapp/portfolio/helpers.py
+++ b/stockapp/portfolio/helpers.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 from ..extensions import db
 from ..models import PortfolioItem, Transaction
-from ..utils import get_locale
+from ..utils import get_locale, convert_currency
 from .. import brokerage
 
 
@@ -181,8 +181,12 @@ def calculate_portfolio_analysis(
             price,
             *_rest,
         ) = get_stock_data_func(item.symbol)
+        target_currency = currency
         if current_user.is_authenticated and current_user.default_currency:
-            currency = current_user.default_currency
+            target_currency = current_user.default_currency
+        if price is not None and currency != target_currency:
+            price = convert_currency(price, currency, target_currency)
+        currency = target_currency
         if price is not None:
             current_price = format_currency(price, currency, locale=get_locale())
             value_num = price * item.quantity

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -62,3 +62,18 @@ def test_api_requires_login(client):
         assert resp.status_code in (302, 401)
         if resp.status_code == 302:
             assert "/login" in resp.headers["Location"]
+
+
+def test_convert_currency(monkeypatch):
+    from stockapp import utils
+
+    utils._cache.clear()
+
+    monkeypatch.setattr(utils, "_fetch_json", lambda url, desc: {"result": 2.0})
+
+    val1 = utils.convert_currency(10, "USD", "EUR")
+    assert val1 == 20
+
+    # should use cached rate on second call
+    val2 = utils.convert_currency(5, "USD", "EUR")
+    assert val2 == 10


### PR DESCRIPTION
## Summary
- add currency conversion utilities using exchangerate.host
- convert stock prices and EPS to the user currency in views
- update portfolio helper to convert prices before calculations
- test currency conversion helpers and page output

## Testing
- `black --check stockapp/main/routes.py stockapp/portfolio/helpers.py stockapp/utils.py tests/test_additional.py tests/test_features.py`
- `flake8 stockapp tests` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686a31ec5c748326a95be43d1b85a31d