### PR TITLE
Add dividend tracking feature

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,7 @@
                         <a href="{{ url_for('watch.watchlist') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Watchlist') }}</a>
                         <a href="{{ url_for('watch.favorites') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Favorites') }}</a>
                         <a href="{{ url_for('portfolio.portfolio') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Portfolio') }}</a>
+                        <a href="{{ url_for('portfolio.dividends') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Dividends') }}</a>
                         <a href="{{ url_for('portfolio.leaderboard') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Leaderboard') }}</a>
                         <a href="{{ url_for('alerts.alerts') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Alerts') }}</a>
                         <a href="{{ url_for('watch.records') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Records') }}</a>

--- a/templates/dividends.html
+++ b/templates/dividends.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}{{ app_name }} - Dividends{% endblock %}
+{% block content %}
+<div class="container py-5">
+    <h3 class="mb-4">Dividend Tracker</h3>
+    {% if dividends %}
+    <div class="table-responsive">
+        <table class="table table-sm">
+            <thead>
+                <tr>
+                    <th>Symbol</th>
+                    <th>Yield %</th>
+                    <th>Upcoming Ex-Date</th>
+                    <th>History</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for d in dividends %}
+                <tr>
+                    <td>{{ d.symbol }}</td>
+                    <td>{% if d.yield is not none %}{{ d.yield }}{% else %}N/A{% endif %}</td>
+                    <td>{% if d.upcoming %}{{ d.upcoming[0].date }}{% else %}N/A{% endif %}</td>
+                    <td>
+                        {% if d.history %}
+                            <ul class="mb-0">
+                            {% for h in d.history %}
+                                <li>{{ h.date }} - {{ h.dividend }}</li>
+                            {% endfor %}
+                            </ul>
+                        {% else %}N/A{% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+    <p>No portfolio items.</p>
+    {% endif %}
+    <a href="{{ url_for('portfolio.portfolio') }}" class="btn btn-secondary mt-3">Back</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- support dividend history and upcoming ex-dates in utils
- show dividend tracking page under portfolio
- schedule daily dividend reminder task
- include new Dividend Tracker link in navbar
- test dividend view and notification tasks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686a33f3cbf88326b8c390ac7357d3e9