### PR TITLE
Add enhanced charting features

### DIFF
--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -17,13 +17,14 @@ from babel.numbers import format_currency, format_decimal
 import json
 from ..utils import (
     get_stock_data,
-    get_historical_prices,
+    get_historical_ohlc,
     get_locale,
     ALERT_PE_THRESHOLD,
     moving_average,
     calculate_rsi,
     calculate_macd,
     bollinger_bands,
+    calculate_cci,
     generate_xlsx,
     notify_user_push,
     convert_currency,
@@ -185,10 +186,17 @@ def index():
                 eps = convert_currency(eps, currency, target_currency)
             currency = target_currency
 
-            history_dates, history_prices = get_historical_prices(symbol, days=90)
+            (
+                history_dates,
+                history_opens,
+                history_highs,
+                history_lows,
+                history_prices,
+            ) = get_historical_ohlc(symbol, days=90)
             ma20 = moving_average(history_prices, 20)
             ma50 = moving_average(history_prices, 50)
             rsi_values = calculate_rsi(history_prices, 14)
+            cci_values = calculate_cci(history_highs, history_lows, history_prices, 20)
             macd_vals, macd_signal = calculate_macd(history_prices)
             bb_upper, bb_lower = bollinger_bands(history_prices, 20, 2)
 
@@ -400,9 +408,13 @@ def index():
         alert_message=alert_message,
         history_dates=history_dates,
         history_prices=history_prices,
+        history_opens=history_opens,
+        history_highs=history_highs,
+        history_lows=history_lows,
         ma20=ma20,
         ma50=ma50,
         rsi_values=rsi_values,
+        cci_values=cci_values,
         macd_values=macd_vals,
         macd_signal=macd_signal,
         bb_upper=bb_upper,

--- a/templates/index.html
+++ b/templates/index.html
@@ -195,18 +195,47 @@
                                             <option value="30">30 Days</option>
                                             <option value="60">60 Days</option>
                                             <option value="90">90 Days</option>
+                                            <option value="180">180 Days</option>
+                                            <option value="365">1 Year</option>
                                         </select>
+                                        <label for="chartType" class="form-label ms-3">Chart:</label>
+                                        <select id="chartType" class="form-select form-select-sm w-auto d-inline-block ms-2">
+                                            <option value="line">Line</option>
+                                            <option value="candlestick">Candlestick</option>
+                                        </select>
+                                    </div>
+                                    <div class="mb-2">
+                                        <label class="form-label">MA Periods:</label>
+                                        <input id="ma1" type="number" value="20" class="form-control form-control-sm d-inline-block" style="width:80px;">
+                                        <input id="ma2" type="number" value="50" class="form-control form-control-sm d-inline-block ms-1" style="width:80px;">
+                                        <div class="form-check form-check-inline ms-2">
+                                            <input class="form-check-input" type="checkbox" id="toggleRSI" checked>
+                                            <label class="form-check-label" for="toggleRSI">RSI</label>
+                                        </div>
+                                        <div class="form-check form-check-inline">
+                                            <input class="form-check-input" type="checkbox" id="toggleCCI">
+                                            <label class="form-check-label" for="toggleCCI">CCI</label>
+                                        </div>
+                                        <div class="form-check form-check-inline">
+                                            <input class="form-check-input" type="checkbox" id="toggleBB" checked>
+                                            <label class="form-check-label" for="toggleBB">Bollinger</label>
+                                        </div>
                                     </div>
                                     <div id="priceChart"></div>
                                     <div id="rsiChart" class="mt-3"></div>
+                                    <div id="cciChart" class="mt-3"></div>
                                     <div id="macdChart" class="mt-3"></div>
                                 </div>
                                 <script>
                                     const fullDates = {{ history_dates|tojson }};
                                     const fullPrices = {{ history_prices|tojson }};
+                                    const fullOpens = {{ history_opens|tojson }};
+                                    const fullHighs = {{ history_highs|tojson }};
+                                    const fullLows = {{ history_lows|tojson }};
                                     const ma20 = {{ ma20|tojson }};
                                     const ma50 = {{ ma50|tojson }};
                                     const rsiValues = {{ rsi_values|tojson }};
+                                    const cciValues = {{ cci_values|tojson }};
                                     const macdVals = {{ macd_values|tojson }};
                                     const macdSignal = {{ macd_signal|tojson }};
                                     const bbUpper = {{ bb_upper|tojson }};
@@ -219,35 +248,64 @@
                                         },
                                         yaxis: { title: 'Price' }
                                     };
+                                    function calcMA(arr, period) {
+                                        const out = [];
+                                        for (let i = 0; i < arr.length; i++) {
+                                            if (i + 1 < period) { out.push(null); continue; }
+                                            let sum = 0;
+                                            for (let j = i + 1 - period; j <= i; j++) sum += arr[j];
+                                            out.push(Math.round((sum / period) * 100) / 100);
+                                        }
+                                        return out;
+                                    }
+
                                     function updateChart(days) {
                                         const dates = fullDates.slice(-days);
                                         const prices = fullPrices.slice(-days);
-                                        const ma20Data = ma20.slice(-days);
-                                        const ma50Data = ma50.slice(-days);
+                                        const opens = fullOpens.slice(-days);
+                                        const highs = fullHighs.slice(-days);
+                                        const lows = fullLows.slice(-days);
+                                        const ma1Period = parseInt(document.getElementById('ma1').value) || 0;
+                                        const ma2Period = parseInt(document.getElementById('ma2').value) || 0;
+                                        const ma1Data = ma1Period ? calcMA(prices, ma1Period).slice(-days) : [];
+                                        const ma2Data = ma2Period ? calcMA(prices, ma2Period).slice(-days) : [];
                                         const rsi = rsiValues.slice(-days);
+                                        const cci = cciValues.slice(-days);
                                         const upper = bbUpper.slice(-days);
                                         const lower = bbLower.slice(-days);
                                         const macd = macdVals.slice(-days);
                                         const signal = macdSignal.slice(-days);
-                                        const priceData = [
-                                            { x: dates, y: prices, mode: 'lines', name: 'Price' },
-                                            { x: dates, y: ma20Data, mode: 'lines', name: 'MA20' },
-                                            { x: dates, y: ma50Data, mode: 'lines', name: 'MA50' },
-                                            { x: dates, y: upper, mode: 'lines', name: 'BB Upper', line: {dash: 'dot'} },
-                                            { x: dates, y: lower, mode: 'lines', name: 'BB Lower', line: {dash: 'dot'} }
-                                        ];
+                                        const chartType = document.getElementById('chartType').value;
+                                        let priceData = [];
+                                        if (chartType === 'candlestick') {
+                                            priceData.push({ x: dates, open: opens, high: highs, low: lows, close: prices, type: 'candlestick', name: 'Price' });
+                                        } else {
+                                            priceData.push({ x: dates, y: prices, mode: 'lines', name: 'Price' });
+                                        }
+                                        if (ma1Period) priceData.push({ x: dates, y: ma1Data, mode: 'lines', name: `MA${ma1Period}` });
+                                        if (ma2Period) priceData.push({ x: dates, y: ma2Data, mode: 'lines', name: `MA${ma2Period}` });
+                                        if (document.getElementById('toggleBB').checked) {
+                                            priceData.push({ x: dates, y: upper, mode: 'lines', name: 'BB Upper', line: {dash:'dot'} });
+                                            priceData.push({ x: dates, y: lower, mode: 'lines', name: 'BB Lower', line: {dash:'dot'} });
+                                        }
                                         Plotly.react('priceChart', priceData, priceLayout, {responsive: true});
                                         const rsiLayout = {
                                             title: 'RSI',
                                             xaxis: { title: 'Date' },
                                             yaxis: { title: 'RSI', range: [0, 100] },
                                             shapes: [
-                                                {type: 'line', x0: dates[0], x1: dates[dates.length-1], y0: 70, y1: 70, line: {dash: 'dash', width: 1, color: 'red'}},
-                                                {type: 'line', x0: dates[0], x1: dates[dates.length-1], y0: 30, y1: 30, line: {dash: 'dash', width: 1, color: 'green'}}
+                                                {type: 'line', x0: dates[0], x1: dates[dates.length-1], y0: 70, y1: 70, line: {dash:'dash', width:1, color:'red'}},
+                                                {type: 'line', x0: dates[0], x1: dates[dates.length-1], y0: 30, y1: 30, line: {dash:'dash', width:1, color:'green'}}
                                             ]
                                         };
                                         const rsiData = [{ x: dates, y: rsi, mode: 'lines', name: 'RSI' }];
-                                        Plotly.react('rsiChart', rsiData, rsiLayout, {responsive: true});
+                                        const cciData = [{ x: dates, y: cci, mode: 'lines', name: 'CCI' }];
+                                        const showRSI = document.getElementById('toggleRSI').checked;
+                                        const showCCI = document.getElementById('toggleCCI').checked;
+                                        document.getElementById('rsiChart').style.display = showRSI ? '' : 'none';
+                                        document.getElementById('cciChart').style.display = showCCI ? '' : 'none';
+                                        if (showRSI) Plotly.react('rsiChart', rsiData, rsiLayout, {responsive: true});
+                                        if (showCCI) Plotly.react('cciChart', cciData, {title:'CCI'}, {responsive: true});
                                         const macdData = [
                                             { x: dates, y: macd, mode: 'lines', name: 'MACD' },
                                             { x: dates, y: signal, mode: 'lines', name: 'Signal' }
@@ -257,6 +315,12 @@
                                     document.getElementById('timeRange').addEventListener('change', (e) => {
                                         updateChart(parseInt(e.target.value));
                                     });
+                                    document.getElementById('chartType').addEventListener('change', () => updateChart(parseInt(document.getElementById('timeRange').value)));
+                                    document.getElementById('ma1').addEventListener('change', () => updateChart(parseInt(document.getElementById('timeRange').value)));
+                                    document.getElementById('ma2').addEventListener('change', () => updateChart(parseInt(document.getElementById('timeRange').value)));
+                                    document.getElementById('toggleRSI').addEventListener('change', () => updateChart(parseInt(document.getElementById('timeRange').value)));
+                                    document.getElementById('toggleCCI').addEventListener('change', () => updateChart(parseInt(document.getElementById('timeRange').value)));
+                                    document.getElementById('toggleBB').addEventListener('change', () => updateChart(parseInt(document.getElementById('timeRange').value)));
                                     updateChart(30);
                                 </script>
                             {% endif %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -26,6 +26,7 @@ def test_indicators():
         calculate_rsi,
         calculate_macd,
         bollinger_bands,
+        calculate_cci,
     )
 
     prices = [1, 2, 3, 4, 5]
@@ -37,6 +38,10 @@ def test_indicators():
     assert len(macd) == len(prices)
     upper, lower = bollinger_bands(prices, period=3, num_std=1)
     assert upper[-1] is not None and lower[-1] is not None
+    highs = [2, 3, 4, 5, 6]
+    lows = [0, 1, 2, 3, 4]
+    cci = calculate_cci(highs, lows, prices, period=3)
+    assert cci[-1] is not None
 
 
 def test_api_endpoints(auth_client, app):


### PR DESCRIPTION
## Summary
- add get_historical_ohlc util and CCI indicator
- support candlestick data and CCI in main route
- expand index chart options with candlestick view and overlays
- test the new calculate_cci helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686a35911ecc83268c0cb3af455cc7dc