### PR TITLE
Add stock screener feature

### DIFF
--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -14,6 +14,7 @@ from .portfolio import portfolio_bp
 from .alerts import alerts_bp
 from .calculators import calc_bp
 from .api import api_bp
+from .screener import screener_bp
 from .tasks import init_celery
 
 
@@ -62,6 +63,7 @@ def create_app(config_class=None):
     app.register_blueprint(portfolio_bp)
     app.register_blueprint(alerts_bp)
     app.register_blueprint(calc_bp)
+    app.register_blueprint(screener_bp)
     app.register_blueprint(api_bp)
 
     with app.app_context():

--- a/stockapp/screener/__init__.py
+++ b/stockapp/screener/__init__.py
@@ -1,0 +1,3 @@
+from .routes import screener_bp
+
+__all__ = ["screener_bp"]

--- a/stockapp/screener/routes.py
+++ b/stockapp/screener/routes.py
@@ -1,0 +1,22 @@
+from flask import Blueprint, render_template, request
+
+from ..utils import screen_stocks
+
+screener_bp = Blueprint("screener", __name__)
+
+
+@screener_bp.route("/screener")
+def screener():
+    filters = {
+        "pe_min": request.args.get("pe_min", type=float),
+        "pe_max": request.args.get("pe_max", type=float),
+        "peg_min": request.args.get("peg_min", type=float),
+        "peg_max": request.args.get("peg_max", type=float),
+        "yield_min": request.args.get("yield_min", type=float),
+        "sector": request.args.get("sector", type=str),
+    }
+    if any(v is not None for v in filters.values()):
+        results = screen_stocks(**filters)
+    else:
+        results = []
+    return render_template("screener.html", results=results)

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,6 +31,7 @@
                         <a href="{{ url_for('alerts.alerts') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Alerts') }}</a>
                         <a href="{{ url_for('watch.records') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Records') }}</a>
                         <a href="{{ url_for('watch.export_history') }}" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">{{ _('Export History') }}</a>
+                        <a href="{{ url_for('screener.screener') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Screener') }}</a>
                         <a href="{{ url_for('calc.interest') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Calculators') }}</a>
                         <a href="{{ url_for('watch.settings') }}" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">{{ _('Settings') }}</a>
                         <a href="{{ url_for('auth.logout') }}" class="btn btn-sm btn-danger">{{ _('Logout') }}</a>
@@ -38,6 +39,7 @@
                 {% else %}
                     <div class="ms-auto d-lg-flex align-items-center">
                         <a href="{{ url_for('portfolio.leaderboard') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Leaderboard') }}</a>
+                        <a href="{{ url_for('screener.screener') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Screener') }}</a>
                         <a href="{{ url_for('auth.login') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Login') }}</a>
                         <a href="{{ url_for('auth.signup') }}" class="btn btn-sm btn-outline-secondary mb-2 mb-lg-0">{{ _('Sign Up') }}</a>
                     </div>

--- a/templates/screener.html
+++ b/templates/screener.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Stock Screener') }}{% endblock %}
+{% block content %}
+<div class="container mt-4">
+    <h2>{{ _('Stock Screener') }}</h2>
+    <form method="get" class="row g-3 mb-4">
+        <div class="col-md-2">
+            <label class="form-label">{{ _('Min P/E') }}</label>
+            <input type="number" step="0.1" name="pe_min" class="form-control" value="{{ request.args.get('pe_min', '') }}">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">{{ _('Max P/E') }}</label>
+            <input type="number" step="0.1" name="pe_max" class="form-control" value="{{ request.args.get('pe_max', '') }}">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">{{ _('Min PEG') }}</label>
+            <input type="number" step="0.1" name="peg_min" class="form-control" value="{{ request.args.get('peg_min', '') }}">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">{{ _('Max PEG') }}</label>
+            <input type="number" step="0.1" name="peg_max" class="form-control" value="{{ request.args.get('peg_max', '') }}">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">{{ _('Min Dividend Yield %') }}</label>
+            <input type="number" step="0.1" name="yield_min" class="form-control" value="{{ request.args.get('yield_min', '') }}">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">{{ _('Sector') }}</label>
+            <input type="text" name="sector" class="form-control" value="{{ request.args.get('sector', '') }}">
+        </div>
+        <div class="col-12">
+            <button class="btn btn-primary" type="submit">{{ _('Filter') }}</button>
+        </div>
+    </form>
+    {% if results %}
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>{{ _('Symbol') }}</th>
+                    <th>{{ _('Company') }}</th>
+                    <th>{{ _('Sector') }}</th>
+                    <th>{{ _('P/E') }}</th>
+                    <th>{{ _('PEG') }}</th>
+                    <th>{{ _('Dividend Yield %') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for r in results %}
+                <tr>
+                    <td>{{ r.symbol }}</td>
+                    <td>{{ r.company }}</td>
+                    <td>{{ r.sector }}</td>
+                    <td>{{ r.pe }}</td>
+                    <td>{{ r.peg }}</td>
+                    <td>{{ r.dividend_yield }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -1,0 +1,17 @@
+def test_screener_route(client, monkeypatch):
+    monkeypatch.setattr(
+        "stockapp.utils.screen_stocks",
+        lambda **k: [
+            {
+                "symbol": "AAA",
+                "company": "Test Co",
+                "sector": "Tech",
+                "pe": 10,
+                "peg": 1.2,
+                "dividend_yield": 2.0,
+            }
+        ],
+    )
+    resp = client.get("/screener?pe_min=5")
+    assert resp.status_code == 200
+    assert b"AAA" in resp.data


### PR DESCRIPTION
## Summary
- add new screener blueprint and routes
- implement `screen_stocks` utility
- create screener template and navigation links
- register screener blueprint
- test the screener page

## Testing
- `black stockapp/screener stockapp/utils.py tests/test_screener.py stockapp/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686a37de7398832688c86cd1a2fc8a28