### PR TITLE
Add OAuth brokerage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ import a file to quickly populate your portfolio. The CSV format uses the
 columns `Symbol`, `Quantity` and `Price Paid`.
 
 * **Portfolio Diversification Analyzer** – automatically analyzes sector allocations, asset correlations and overall portfolio volatility to highlight concentration risk. Enhanced metrics like Beta, Sharpe ratio, Value at Risk and Monte Carlo simulations provide deeper risk insights.
-* **Brokerage Transaction Sync** – portfolio holdings and recent transactions can now be synchronized from connected brokerage accounts using the new stub API.
+* **Brokerage Transaction Sync** – connect your real brokerage via OAuth to automatically import holdings, transactions and account balances. A demo token is still supported for tests.
 
 ## Social Features
 

--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -14,6 +14,7 @@ from .portfolio import portfolio_bp
 from .alerts import alerts_bp
 from .calculators import calc_bp
 from .api import api_bp
+from .brokerage_routes import broker_bp
 from .screener import screener_bp
 from .tasks import init_celery
 
@@ -65,6 +66,7 @@ def create_app(config_class=None):
     app.register_blueprint(calc_bp)
     app.register_blueprint(screener_bp)
     app.register_blueprint(api_bp)
+    app.register_blueprint(broker_bp)
 
     with app.app_context():
         db.create_all()

--- a/stockapp/brokerage_routes.py
+++ b/stockapp/brokerage_routes.py
@@ -1,0 +1,45 @@
+from flask import Blueprint, redirect, request, url_for, session
+from flask_login import login_required, current_user
+
+from . import brokerage
+from .extensions import db
+
+broker_bp = Blueprint("broker", __name__)
+
+
+@broker_bp.route("/brokerage/connect")
+@login_required
+def connect():
+    state = brokerage.generate_state()
+    session["broker_oauth_state"] = state
+    return redirect(brokerage.get_authorization_url(state))
+
+
+@broker_bp.route("/brokerage/callback")
+@login_required
+def callback():
+    stored = session.pop("broker_oauth_state", None)
+    state = request.args.get("state")
+    code = request.args.get("code")
+    if not code or stored != state:
+        return redirect(url_for("portfolio.portfolio"))
+    token_data = brokerage.exchange_code_for_token(code)
+    if not token_data:
+        return redirect(url_for("portfolio.portfolio"))
+    current_user.brokerage_access_token = token_data.get("access_token")
+    current_user.brokerage_refresh_token = token_data.get("refresh_token")
+    expires_in = token_data.get("expires_in")
+    if expires_in:
+        current_user.brokerage_token_expiry = brokerage.token_expiry_time(expires_in)
+    db.session.commit()
+    return redirect(url_for("portfolio.portfolio"))
+
+
+@broker_bp.route("/brokerage/disconnect")
+@login_required
+def disconnect():
+    current_user.brokerage_access_token = None
+    current_user.brokerage_refresh_token = None
+    current_user.brokerage_token_expiry = None
+    db.session.commit()
+    return redirect(url_for("portfolio.portfolio"))

--- a/stockapp/models.py
+++ b/stockapp/models.py
@@ -26,6 +26,9 @@ class User(db.Model, UserMixin):
     language = db.Column(db.String(5), default="en")
     theme = db.Column(db.String(10), default="light")
     brokerage_token = db.Column(db.String(100))
+    brokerage_access_token = db.Column(db.String(200))
+    brokerage_refresh_token = db.Column(db.String(200))
+    brokerage_token_expiry = db.Column(db.DateTime)
 
 
 class WatchlistItem(db.Model):

--- a/stockapp/portfolio/routes.py
+++ b/stockapp/portfolio/routes.py
@@ -73,9 +73,15 @@ def export_portfolio():
 @portfolio_bp.route("/portfolio/sync")
 @login_required
 def sync_brokerage():
-    if not current_user.brokerage_token:
+    token = current_user.brokerage_access_token or current_user.brokerage_token
+    if not token:
         return redirect(url_for("portfolio.portfolio"))
-    sync_portfolio_from_brokerage(current_user.id, current_user.brokerage_token)
+    sync_portfolio_from_brokerage(
+        current_user.id,
+        token,
+        refresh=current_user.brokerage_refresh_token,
+        expiry=current_user.brokerage_token_expiry,
+    )
     return redirect(url_for("portfolio.portfolio"))
 
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -38,6 +38,13 @@
             </select>
             <label class="form-label mt-3">{{ _('Brokerage API Token') }}</label>
             <input type="text" name="brokerage_token" class="form-control" value="{{ brokerage_token }}">
+            <div class="mt-2">
+                {% if current_user.brokerage_access_token %}
+                    <a href="{{ url_for('broker.disconnect') }}" class="btn btn-warning btn-sm">{{ _('Disconnect Brokerage') }}</a>
+                {% else %}
+                    <a href="{{ url_for('broker.connect') }}" class="btn btn-secondary btn-sm">{{ _('Connect Brokerage') }}</a>
+                {% endif %}
+            </div>
             <button class="btn btn-primary mt-3" type="submit">{{ _('Save') }}</button>
         </form>
         <a href="{{ url_for('main.index') }}" class="btn btn-secondary">{{ _('Back') }}</a>

--- a/tests/test_brokerage.py
+++ b/tests/test_brokerage.py
@@ -1,6 +1,7 @@
 import pytest
 
 from stockapp.portfolio.helpers import sync_transactions_from_brokerage
+from stockapp import brokerage
 from stockapp.models import User, PortfolioItem, Transaction
 from stockapp.extensions import db
 
@@ -16,3 +17,8 @@ def test_sync_transactions(app):
         }
         assert "AAA" in items
         assert items["AAA"].quantity >= 1
+
+
+def test_account_balance():
+    bal = brokerage.get_account_balance("demo-token")
+    assert bal == 10000.0


### PR DESCRIPTION
## Summary
- implement OAuth-based brokerage integration
- add blueprint for brokerage auth flow
- store brokerage tokens in user model
- refresh and use access tokens during sync tasks
- update settings UI with connect/disconnect buttons
- document OAuth integration
- tests for account balance

## Testing
- `black stockapp tests --quiet`
- `flake8 stockapp tests` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686a4344885c83269af4172999d2c131