### PR TITLE
Extend chart history range

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Alongside the standard P/E ratio the app now fetches and displays:
 * **Dividend Payout Ratio** – shows what percentage of earnings are distributed as dividends.
 * **Current Ratio** – current assets divided by current liabilities, indicating short-term liquidity.
 * **MACD and Bollinger Bands** – additional technical indicators for chart analysis.
+* **Enhanced Charting** – candlestick views with adjustable time ranges and optional overlays like RSI, CCI and moving averages of any length.
 
 These extra metrics appear on the main page and in exported CSV/PDF/XLSX/JSON files.
 

--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -192,7 +192,7 @@ def index():
                 history_highs,
                 history_lows,
                 history_prices,
-            ) = get_historical_ohlc(symbol, days=90)
+            ) = get_historical_ohlc(symbol, days=365)
             ma20 = moving_average(history_prices, 20)
             ma50 = moving_average(history_prices, 50)
             rsi_values = calculate_rsi(history_prices, 14)


### PR DESCRIPTION
## Summary
- fetch up to 365 days of historical data for main chart
- document enhanced charting features in README

## Testing
- `black --check .` *(fails: would reformat two files)*
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686b1fc402c88326b99921e98d6d9345