### PR TITLE
Enhance mobile UI and add dark theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ The app registers a small service worker so it can behave like a Progressive
 Web App. Only static assets are cached. The main pages are always fetched from
 the server so that dynamic CSRF tokens stay valid.
 
+### Mobile UI and Dark Theme
+
+When logged in you can quickly switch between light and dark modes using the
+toggle in the navigation bar. Forms and tables now adapt better on small
+screens thanks to additional responsive styles.
+
 ### WebSocket Price Streaming
 
 Price updates are now pushed over a WebSocket connection. When viewing a

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,6 @@
+@media (max-width: 576px) {
+  .stack-sm > * {
+    flex: 0 0 100% !important;
+    max-width: 100% !important;
+  }
+}

--- a/stockapp/watchlists/routes.py
+++ b/stockapp/watchlists/routes.py
@@ -203,6 +203,14 @@ def settings():
     )
 
 
+@watch_bp.route("/toggle_theme", methods=["POST"])
+@login_required
+def toggle_theme():
+    current_user.theme = "dark" if current_user.theme == "light" else "light"
+    db.session.commit()
+    return redirect(request.referrer or url_for("main.index"))
+
+
 @watch_bp.route("/export_history")
 @login_required
 def export_history():

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{{ app_name }}{% endblock %}</title>
     <link href="{{ url_for('static', filename='vendor/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ url_for('static', filename='style.css') }}" rel="stylesheet">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
     {% block head %}{% endblock %}
 </head>
@@ -34,6 +35,12 @@
                         <a href="{{ url_for('screener.screener') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Screener') }}</a>
                         <a href="{{ url_for('calc.interest') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Calculators') }}</a>
                         <a href="{{ url_for('watch.settings') }}" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">{{ _('Settings') }}</a>
+                        <form method="post" action="{{ url_for('watch.toggle_theme') }}" class="d-inline">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">
+                                {% if current_user.theme == 'dark' %}{{ _('Light Theme') }}{% else %}{{ _('Dark Theme') }}{% endif %}
+                            </button>
+                        </form>
                         <a href="{{ url_for('auth.logout') }}" class="btn btn-sm btn-danger">{{ _('Logout') }}</a>
                     </div>
                 {% else %}

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -12,7 +12,7 @@
         <h3 class="mb-4">Portfolio</h3>
         <form method="POST" class="mb-3">
             {{ add_form.hidden_tag() }}
-            <div class="row g-2">
+            <div class="row g-2 stack-sm">
                 <div class="col">
                     <input type="text" name="symbol" class="form-control" placeholder="Symbol" required>
                 </div>

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -7,7 +7,7 @@
         <h3 class="mb-4">Watchlist</h3>
         <form method="POST" class="mb-3">
             {{ add_form.hidden_tag() }}
-            <div class="row g-2">
+            <div class="row g-2 stack-sm">
                 <div class="col">
                     {{ add_form.symbol(class="form-control", placeholder="Symbol") }}
                 </div>
@@ -45,7 +45,7 @@
                 <form method="POST" class="d-flex flex-column gap-2">
                     {{ update_form.hidden_tag() }}
                     <input type="hidden" name="item_id" value="{{ item.id }}">
-                    <div class="d-flex align-items-center gap-2">
+                    <div class="d-flex flex-column flex-md-row align-items-md-center gap-2 stack-sm">
                         <strong>{{ item.symbol }}</strong>
                         <input type="number" name="threshold" value="{{ item.pe_threshold }}" class="form-control d-inline-block w-auto" />
                         <input type="number" name="de_threshold" value="{{ item.de_threshold or '' }}" class="form-control d-inline-block w-auto" placeholder="D/E" />

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -507,3 +507,16 @@ def test_dividend_notifications(app, monkeypatch):
     with app.app_context():
         alert = Alert.query.filter_by(user_id=u.id).first()
         assert alert and "DVD" in alert.message
+
+
+def test_theme_toggle(auth_client, app):
+    with app.app_context():
+        user = User.query.filter_by(username="tester").first()
+        user.theme = "light"
+        from stockapp.extensions import db
+        db.session.commit()
+    resp = auth_client.post("/toggle_theme", follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        user = User.query.filter_by(username="tester").first()
+        assert user.theme == "dark"


### PR DESCRIPTION
## Summary
- add responsive `stack-sm` style
- include global stylesheet in base template
- add form class for watchlist and portfolio forms
- add dark theme toggle in navbar
- implement `/toggle_theme` route
- test the theme toggle functionality
- document mobile UI improvements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686b2a791a588326b84bf52db3883445