### PR TITLE
Add news sentiment analysis

### DIFF
--- a/stockapp/watchlists/routes.py
+++ b/stockapp/watchlists/routes.py
@@ -84,6 +84,13 @@ def watchlist():
         .all()
     )
     news = {i.symbol: get_stock_news(i.symbol, limit=3) for i in items}
+    sentiments = {}
+    for sym, articles in news.items():
+        if articles:
+            avg = sum(a.get("sentiment", 0) for a in articles) / len(articles)
+            sentiments[sym] = round(avg, 2)
+        else:
+            sentiments[sym] = None
     return render_template(
         "watchlist.html",
         items=items,
@@ -91,6 +98,7 @@ def watchlist():
         update_form=update_form,
         default_threshold=ALERT_PE_THRESHOLD,
         news=news,
+        sentiments=sentiments,
     )
 
 
@@ -287,9 +295,17 @@ def public_watchlist(username):
     user = User.query.filter_by(username=username).first_or_404()
     items = WatchlistItem.query.filter_by(user_id=user.id, is_public=True).all()
     news = {i.symbol: get_stock_news(i.symbol, limit=3) for i in items}
+    sentiments = {}
+    for sym, articles in news.items():
+        if articles:
+            avg = sum(a.get("sentiment", 0) for a in articles) / len(articles)
+            sentiments[sym] = round(avg, 2)
+        else:
+            sentiments[sym] = None
     return render_template(
         "public_watchlist.html",
         items=items,
         user=user,
         news=news,
+        sentiments=sentiments,
     )

--- a/templates/public_watchlist.html
+++ b/templates/public_watchlist.html
@@ -8,12 +8,19 @@
     {% for item in items %}
     <li class="list-group-item">
       <strong>{{ item.symbol }}</strong>
+      {% if sentiments[item.symbol] is not none %}
+      <span class="badge bg-info text-dark">Sentiment {{ '%.2f'|format(sentiments[item.symbol]) }}</span>
+      {% endif %}
       {% if news[item.symbol] %}
       <ul class="mt-2">
         {% for n in news[item.symbol] %}
         <li>
           <a href="{{ n.url }}" target="_blank">{{ n.headline }}</a>
+          {% if n.sentiment is defined %}
+          <small class="text-muted">{{ n.published }} ({{ '%.2f'|format(n.sentiment) }})</small>
+          {% else %}
           <small class="text-muted">{{ n.published }}</small>
+          {% endif %}
         </li>
         {% endfor %}
       </ul>

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -47,6 +47,9 @@
                     <input type="hidden" name="item_id" value="{{ item.id }}">
                     <div class="d-flex flex-column flex-md-row align-items-md-center gap-2 stack-sm">
                         <strong>{{ item.symbol }}</strong>
+                        {% if sentiments[item.symbol] is not none %}
+                        <span class="badge bg-info text-dark">Sentiment {{ '%.2f'|format(sentiments[item.symbol]) }}</span>
+                        {% endif %}
                         <input type="number" name="threshold" value="{{ item.pe_threshold }}" class="form-control d-inline-block w-auto" />
                         <input type="number" name="de_threshold" value="{{ item.de_threshold or '' }}" class="form-control d-inline-block w-auto" placeholder="D/E" />
                         <input type="number" name="rsi_threshold" value="{{ item.rsi_threshold or '' }}" class="form-control d-inline-block w-auto" placeholder="RSI" />
@@ -66,7 +69,11 @@
                     {% for n in news[item.symbol] %}
                     <li>
                         <a href="{{ n.url }}" target="_blank">{{ n.headline }}</a>
+                        {% if n.sentiment is defined %}
+                        <small class="text-muted">{{ n.published }} ({{ '%.2f'|format(n.sentiment) }})</small>
+                        {% else %}
                         <small class="text-muted">{{ n.published }}</small>
+                        {% endif %}
                     </li>
                     {% endfor %}
                 </ul>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -44,6 +44,33 @@ def test_indicators():
     assert cci[-1] is not None
 
 
+def test_news_sentiment(monkeypatch):
+    from stockapp import utils
+
+    utils._cache.clear()
+
+    sample = [
+        {
+            "title": "Stock surges on strong growth",
+            "url": "u1",
+            "publishedDate": "2023-01-01",
+        },
+        {
+            "title": "Shares drop after bad results",
+            "url": "u2",
+            "publishedDate": "2023-01-02",
+        },
+    ]
+
+    monkeypatch.setattr(utils, "_fetch_json", lambda url, desc, symbol=None: sample)
+
+    news = utils.get_stock_news("AAA", limit=2)
+    assert len(news) == 2
+    sentiments = [a["sentiment"] for a in news]
+    assert sentiments[0] > 0
+    assert sentiments[1] < 0
+
+
 def test_api_endpoints(auth_client, app):
     from stockapp.models import WatchlistItem, PortfolioItem, Alert, User
     from stockapp.extensions import db


### PR DESCRIPTION
## Summary
- analyze headline sentiment with simple keyword method
- include sentiment scores in fetched news
- show sentiment on watchlist and public watchlist pages
- add tests for the new sentiment function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Flask)*

------
https://chatgpt.com/codex/tasks/task_e_686b2be9730c83269e9fd251a41dab85