### PR TITLE
Graceful fallback when API key is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ store secrets in the source code:
 
 * `SECRET_KEY` &ndash; Flask session secret. If omitted, a random key is generated
   at startup. **In production this variable must be set or the app will not start.**
-* `API_KEY` &ndash; Financial Modeling Prep API key (required).
+* `API_KEY` &ndash; Financial Modeling Prep API key. When not set, placeholder data is
+  returned instead of live market data.
 * `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD` &ndash; SMTP
   credentials for sending alert emails.
 * `FLASK_DEBUG` &ndash; Set to `1` to enable Flask debug mode (defaults to `0`).

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import importlib
+import os
+
+
+def test_no_api_key_returns_placeholders(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    import stockapp.utils as utils
+
+    importlib.reload(utils)
+    assert utils.API_KEY_MISSING
+
+    dates, prices = utils.get_historical_prices("AAPL", 1)
+    assert dates == [] and prices == []
+
+    data = utils.get_stock_data("AAPL")
+    assert len(data) == 23 and all(item is None for item in data)
+
+    assert utils.get_stock_news("AAPL") == []
+    assert utils.screen_stocks() == []


### PR DESCRIPTION
## Summary
- avoid raising an error when `API_KEY` is absent
- return placeholder data instead of making external calls
- document optional API key behaviour in README
- add regression test for missing API key

## Testing
- `black stockapp/utils.py tests/test_utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686c809b73c08326816cf4d55bf2c547