### PR TITLE
Create default user only in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,16 @@ URL can be assigned to `REDIS_URL` if you want API caching enabled.
 
 ### Default Login
 
-On startup the app creates a verified user if it doesn't already exist. The
+When running in development mode (`FLASK_ENV=development`) the app creates a
+verified user if one doesn't already exist. This makes local testing easier. The
 default credentials are:
 
 * Username: `testuser`
 * Password: `testpass`
 
-You can override these by setting the `DEFAULT_USERNAME` and `DEFAULT_PASSWORD`
-environment variables before running the app.
+You can override these by setting `DEFAULT_USERNAME` and `DEFAULT_PASSWORD`.
+The account is **not** created when `FLASK_ENV` is anything other than
+`development`.
 
 ## Account Verification and Password Reset
 

--- a/stockapp/__init__.py
+++ b/stockapp/__init__.py
@@ -71,21 +71,22 @@ def create_app(config_class=None):
     with app.app_context():
         db.create_all()
 
-        # Create a default user for testing if credentials provided
-        default_user = os.environ.get("DEFAULT_USERNAME", "testuser")
-        default_pass = os.environ.get("DEFAULT_PASSWORD", "testpass")
-        if default_user and default_pass:
-            if not User.query.filter_by(username=default_user).first():
-                user = User(
-                    username=default_user,
-                    password_hash=generate_password_hash(default_pass),
-                    is_verified=True,
-                    default_currency="USD",
-                    language="en",
-                    theme="light",
-                )
-                db.session.add(user)
-                db.session.commit()
+        # Only create the default user in development mode
+        if app.config.get("ENV") == "development":
+            default_user = os.environ.get("DEFAULT_USERNAME", "testuser")
+            default_pass = os.environ.get("DEFAULT_PASSWORD", "testpass")
+            if default_user and default_pass:
+                if not User.query.filter_by(username=default_user).first():
+                    user = User(
+                        username=default_user,
+                        password_hash=generate_password_hash(default_pass),
+                        is_verified=True,
+                        default_currency="USD",
+                        language="en",
+                        theme="light",
+                    )
+                    db.session.add(user)
+                    db.session.commit()
 
     init_celery(app)
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from stockapp import create_app
 def app(monkeypatch):
     os.environ["DATABASE_URL"] = "sqlite:///:memory:"
     os.environ.setdefault("API_KEY", "demo")
+    os.environ["FLASK_ENV"] = "development"
     os.environ["DEFAULT_USERNAME"] = "tester"
     os.environ["DEFAULT_PASSWORD"] = "password"
     app = create_app()


### PR DESCRIPTION
## Summary
- restrict default user creation to development environment
- set `FLASK_ENV` in tests so user is created
- update docs about default login

## Testing
- `black --check stockapp/__init__.py tests/conftest.py`
- `flake8 stockapp/__init__.py tests/conftest.py` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686c87f056c883268fb1acb3d44db24b