### PR TITLE
Add bootstrap script for tests and linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,15 @@ This Flask application calculates P/E ratios and stores user data using SQLAlche
 ## Quickstart
 
 1. Copy `.env.example` to `.env` and edit the values.
-2. Create the virtual environment and install dependencies:
+2. Install all required dependencies and build the frontend assets
+   using the provided bootstrap script:
    ```bash
-   ./setup_env.sh
+   ./scripts/bootstrap.sh
    source venv/bin/activate
    ```
-3. Build the frontend assets:
-   ```bash
-   npm install
-   npm run build
-   ```
+   This combines the previous `setup_env.sh` and manual `npm` steps.
+3. (Optional) If you prefer to manage the steps manually you can still
+   run `./setup_env.sh` followed by `npm install && npm run build`.
 4. Start the application:
    ```bash
    python app.py
@@ -92,16 +91,17 @@ export TWILIO_FROM="+15551234567"
 
 ## Setup
 
-Install dependencies and create a virtual environment by running the helper
-script included in the repository:
+Install dependencies and create a virtual environment by running the
+bootstrap helper script:
 
 ```bash
-./setup_env.sh
+./scripts/bootstrap.sh
 source venv/bin/activate
 ```
 
-The script creates a `venv/` directory in the project root and installs the
-packages listed in `requirements.txt`.
+This will create a `venv/` directory and also fetch the frontend assets so
+tests and linters can run immediately. The older `./setup_env.sh` script is
+still provided if you only want to install the Python packages.
 
 If your environment does not have internet access you can install dependencies
 from a local **wheelhouse** directory instead. First, on a machine with

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,14 +3,20 @@
 Thank you for considering a contribution! The steps below outline the typical
 workflow:
 
-1. Create a Python virtual environment and install dependencies:
+1. Create a Python virtual environment and install dependencies. The
+   easiest way is to run the bootstrap script which also installs the
+   frontend packages:
 
    ```bash
-   ./setup_env.sh
+   ./scripts/bootstrap.sh
    source venv/bin/activate
    ```
 
-2. Install frontend packages and build the static assets:
+   The previous `setup_env.sh` script remains available if you prefer
+   to manage the Node dependencies separately.
+
+2. If you skip the bootstrap script, install the frontend packages and
+   build the static assets manually:
 
    ```bash
    npm install

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Simple bootstrap script to install all dependencies needed for
+# running tests and linters. This sets up the Python virtual
+# environment, installs Python packages, and fetches frontend
+# assets.
+set -e
+
+# Create Python virtual environment and install packages
+./setup_env.sh "$@"
+source venv/bin/activate
+
+# Install frontend node modules and build assets
+if [ -f package.json ]; then
+    npm install
+    npm run build
+fi
+
+echo "Bootstrap complete. Activate the virtualenv with 'source venv/bin/activate' and run 'pytest' or 'flake8' as needed."


### PR DESCRIPTION
## Summary
- add `scripts/bootstrap.sh` to set up test environment
- document bootstrap process in README and contributing guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c88dfc4548326a728641536dd2de7