### PR TITLE
Improve notification reliability

### DIFF
--- a/docs/advanced_features.md
+++ b/docs/advanced_features.md
@@ -24,6 +24,8 @@ caching.
 The schedules for periodic tasks can also be overridden by setting
 `CHECK_WATCHLISTS_CRON`, `SEND_TREND_SUMMARIES_CRON`, `SYNC_BROKERAGE_CRON` and
 `CHECK_DIVIDENDS_CRON` to cron strings.
+Notification emails and SMS messages are queued through Celery so failed
+deliveries are automatically retried.
 
 ## SMS Notifications
 


### PR DESCRIPTION
## Summary
- raise `NotificationError` from notification helpers
- add Celery tasks with retry for email and SMS
- queue outgoing messages via new tasks
- handle email failures in signup and password reset forms
- document Celery retry behaviour
- update tests for new async tasks

## Testing
- `black .`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError for Flask)*

------
https://chatgpt.com/codex/tasks/task_e_6871de26804883268b57094ccb6f2161