### PR TITLE
Add tests for Celery task wrappers

### DIFF
--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -1,0 +1,29 @@
+import pytest
+from stockapp.tasks import (
+    check_watchlists_task,
+    send_trend_summaries_task,
+    check_dividends_task,
+)
+
+
+def test_check_watchlists_task_invokes_helper(monkeypatch):
+    called = []
+    monkeypatch.setattr("stockapp.tasks._check_watchlists", lambda: called.append(True))
+    check_watchlists_task()
+    assert called
+
+
+def test_send_trend_summaries_task_invokes_helper(monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        "stockapp.tasks._send_trend_summaries", lambda: called.append(True)
+    )
+    send_trend_summaries_task()
+    assert called
+
+
+def test_check_dividends_task_invokes_helper(monkeypatch):
+    called = []
+    monkeypatch.setattr("stockapp.tasks._check_dividends", lambda: called.append(True))
+    check_dividends_task()
+    assert called


### PR DESCRIPTION
## Summary
- cover Celery task wrappers with unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6871e2300f4083269c05bffbe86bbe0f