### PR TITLE
Improve production config checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The repository includes several guides to keep this README concise:
 
 * [Usage instructions](docs/usage.md)
 * [Environment variables](docs/environment.md)
+* [Secure deployment](docs/deployment.md)
 * [Advanced features](docs/advanced_features.md)
 * [Contributing](docs/contributing.md)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,32 @@
+# Secure Deployment
+
+This guide covers the minimum configuration required to run MarketMinder in production.
+
+## Required Environment Variables
+
+At a minimum the following variables **must** be provided when `FLASK_ENV=production`:
+
+- `SECRET_KEY` – secret used by Flask for sessions
+- `DATABASE_URL` – connection string for the production database
+- `TWILIO_SID`, `TWILIO_TOKEN` and `TWILIO_FROM` – credentials for SMS alerts
+
+Set these values as environment variables rather than storing them in source control. A sample snippet is shown below:
+
+```bash
+export FLASK_ENV=production
+export SECRET_KEY="change_me"
+export DATABASE_URL="postgresql://user:pass@db-host/dbname"
+export TWILIO_SID="ACxxxxxxxx"
+export TWILIO_TOKEN="your_auth_token"
+export TWILIO_FROM="+15551234567"
+```
+
+## Starting the Application
+
+After setting the variables above you can start the server with a WSGI runner such as Gunicorn:
+
+```bash
+gunicorn -w 4 -b 0.0.0.0:8000 'stockapp:create_app()'
+```
+
+When deploying with Docker or another container system make sure these variables are provided in the runtime environment.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -73,6 +73,15 @@ Provide your own Redis instance for Celery in production. Set `CELERY_BROKER_URL
 `CELERY_RESULT_BACKEND` to the connection string. Assign the same value to `REDIS_URL` if you
 would like API caching enabled.
 
+When running with `FLASK_ENV=production` the app requires several environment
+variables:
+
+- `SECRET_KEY`
+- `DATABASE_URL`
+- `TWILIO_SID`, `TWILIO_TOKEN`, `TWILIO_FROM`
+
+See [Secure deployment](deployment.md) for a sample startup snippet.
+
 ### Default Login
 
 When `FLASK_ENV=development` a verified user is created automatically if one does not already

--- a/stockapp/config.py
+++ b/stockapp/config.py
@@ -58,8 +58,12 @@ class Config:
         self.TWILIO_SID = os.environ.get("TWILIO_SID", self.TWILIO_SID)
         self.TWILIO_TOKEN = os.environ.get("TWILIO_TOKEN", self.TWILIO_TOKEN)
         self.TWILIO_FROM = os.environ.get("TWILIO_FROM", self.TWILIO_FROM)
-        self.VAPID_PUBLIC_KEY = os.environ.get("VAPID_PUBLIC_KEY", self.VAPID_PUBLIC_KEY)
-        self.VAPID_PRIVATE_KEY = os.environ.get("VAPID_PRIVATE_KEY", self.VAPID_PRIVATE_KEY)
+        self.VAPID_PUBLIC_KEY = os.environ.get(
+            "VAPID_PUBLIC_KEY", self.VAPID_PUBLIC_KEY
+        )
+        self.VAPID_PRIVATE_KEY = os.environ.get(
+            "VAPID_PRIVATE_KEY", self.VAPID_PRIVATE_KEY
+        )
         self.CHECK_WATCHLISTS_CRON = os.environ.get(
             "CHECK_WATCHLISTS_CRON", self.CHECK_WATCHLISTS_CRON
         )
@@ -85,3 +89,14 @@ class ProductionConfig(Config):
         super().__init__()
         if not os.environ.get("SECRET_KEY"):
             raise RuntimeError("SECRET_KEY must be set in production")
+        if not os.environ.get("DATABASE_URL"):
+            raise RuntimeError("DATABASE_URL must be set in production")
+        missing_twilio = [
+            var
+            for var in ("TWILIO_SID", "TWILIO_TOKEN", "TWILIO_FROM")
+            if not os.environ.get(var)
+        ]
+        if missing_twilio:
+            raise RuntimeError(
+                "Missing Twilio configuration: " + ", ".join(missing_twilio)
+            )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+from stockapp.config import ProductionConfig
+
+
+def test_production_requires_secret_key(monkeypatch):
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example/db")
+    monkeypatch.setenv("TWILIO_SID", "sid")
+    monkeypatch.setenv("TWILIO_TOKEN", "token")
+    monkeypatch.setenv("TWILIO_FROM", "+1000")
+    with pytest.raises(RuntimeError):
+        ProductionConfig()
+
+
+def test_production_requires_database(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "secret")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("TWILIO_SID", "sid")
+    monkeypatch.setenv("TWILIO_TOKEN", "token")
+    monkeypatch.setenv("TWILIO_FROM", "+1000")
+    with pytest.raises(RuntimeError):
+        ProductionConfig()
+
+
+def test_production_requires_twilio(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "secret")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example/db")
+    monkeypatch.delenv("TWILIO_SID", raising=False)
+    monkeypatch.delenv("TWILIO_TOKEN", raising=False)
+    monkeypatch.delenv("TWILIO_FROM", raising=False)
+    with pytest.raises(RuntimeError):
+        ProductionConfig()


### PR DESCRIPTION
## Summary
- enforce DATABASE_URL and Twilio env vars in production
- add secure deployment instructions
- document new requirements
- test ProductionConfig checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6871e762b9148326854fb4e7f0d075fa