### PR TITLE
Add architecture doc and Docker quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ The repository includes several guides to keep this README concise:
 * [Secure deployment](docs/deployment.md)
 * [Advanced features](docs/advanced_features.md)
 * [Contributing](docs/contributing.md)
+* [Architecture overview](docs/architecture.md)
 
 Visit those pages for setup steps, configuration options and details on optional functionality.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,38 @@
+# Architecture Overview
+
+This page describes the main components of MarketMinder and how they interact.
+
+```
++----------------+      +--------------------+      +--------------+
+| Flask App      | <--> | SQLAlchemy Models  | <--> | Database      |
++----------------+      +--------------------+      +--------------+
+        |
+        | registers
+        v
++----------------+      +-------------+
+| Blueprints     |----->| Templates   |
++----------------+      +-------------+
+        |
+        | triggers
+        v
++---------------+       +---------------+
+| Celery Worker | <---- | Redis Broker  |
++---------------+       +---------------+
+        |
+        | schedules
+        v
++-----------------+
+| Background Jobs |
++-----------------+
+```
+
+- **Flask App** – created in `app.py` using `create_app()` from the `stockapp` package.
+- **Blueprints** – modular routes for authentication, watchlists, portfolios and more.
+- **SQLAlchemy Models** – define users, alerts, stock records and other data structures.
+- **Database** – SQLite by default or PostgreSQL in production.
+- **Celery Worker** – executes scheduled tasks such as watchlist checks and email alerts.
+- **Redis Broker** – default message broker for Celery and optional caching layer.
+
+When the application starts it registers all blueprints and initializes the
+extensions. Background jobs are scheduled through Celery and stored in the
+configured broker. Results and user data are persisted in the database.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,6 +29,18 @@ docker compose up --build
 
 The web interface will be available at <http://localhost:5000>.
 
+### Standalone Docker Image
+
+If you prefer running a single container, a `Dockerfile` is provided. Build and
+run the image with:
+
+```bash
+docker build -t marketminder .
+docker run -p 5000:5000 --env-file .env marketminder
+```
+
+This uses Gunicorn to serve the application on port 5000.
+
 ### Database Configuration
 
 SQLite is used by default for local development. To use PostgreSQL set `DATABASE_URL`.


### PR DESCRIPTION
## Summary
- include architecture diagrams
- add Dockerfile quickstart instructions
- link to new docs in README

## Testing
- `pytest -q` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6871ec229ab883269848af207130b6c0