### PR TITLE
Pin frontend JS deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Build frontend assets
 COPY package.json ./package.json
 COPY scripts ./scripts
-RUN npm install && npm run build
+RUN npm ci && npm run build
 
 COPY . .
 

--- a/docs/advanced_features.md
+++ b/docs/advanced_features.md
@@ -100,8 +100,8 @@ are configured.
 
 ## Frontend Assets
 
-Bootstrap and Plotly are managed locally. Run `npm install && npm run build` once after cloning to populate
-`static/vendor/` so the service worker can cache the assets.
+Bootstrap and Plotly are managed locally. Run `npm ci && npm run build` once after cloning to populate
+`static/vendor/` so the service worker can cache the assets using the versions pinned in `package.json`.
 
 ## Localization
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,9 +19,11 @@ workflow:
    build the static assets manually:
 
    ```bash
-   npm install
+   npm ci
    npm run build
    ```
+   The `package.json` file pins Bootstrap and Plotly versions so `npm ci`
+   installs exactly those dependencies for reproducible builds.
 
 3. Run the unit tests and style checks before committing:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,8 @@ This page covers basic setup and workflow for running MarketMinder locally.
    ./scripts/bootstrap.sh
    source venv/bin/activate
    ```
-   You may also run `./setup_env.sh` and `npm install && npm run build` manually.
+   You may also run `./setup_env.sh` and `npm ci && npm run build` manually to
+   use the pinned asset versions.
 3. Start the application:
    ```bash
    python app.py

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "devDependencies": {
     "bootstrap": "5.3.2",
-    "plotly.js-dist-min": "^2"
+    "plotly.js-dist-min": "2.27.0"
   },
   "scripts": {
     "build": "node scripts/build_assets.js"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -11,7 +11,7 @@ source venv/bin/activate
 
 # Install frontend node modules and build assets
 if [ -f package.json ]; then
-    npm install
+    npm ci
     npm run build
 fi
 

--- a/scripts/build_assets.js
+++ b/scripts/build_assets.js
@@ -27,7 +27,7 @@ function main() {
       copy(src, dest);
       console.log(`Copied ${src} -> ${dest}`);
     } else {
-      console.warn(`Missing ${src}, did you run \`npm install\`?`);
+      console.warn(`Missing ${src}, did you run \`npm ci\`?`);
     }
   }
 }

--- a/static/vendor/README.md
+++ b/static/vendor/README.md
@@ -1,2 +1,2 @@
 This directory stores third-party frontend assets.
-Run `npm install` and `npm run build` to populate it with Bootstrap and Plotly files.
+Run `npm ci` and `npm run build` to populate it with Bootstrap and Plotly files using the pinned versions.

--- a/stockapp/main/export_helpers.py
+++ b/stockapp/main/export_helpers.py
@@ -7,7 +7,7 @@ from fpdf import FPDF
 from ..utils import generate_xlsx
 
 
-def csv_response(symbol: str, headers: list[str], row: list) -> 'Response':
+def csv_response(symbol: str, headers: list[str], row: list) -> "Response":
     """Return a CSV file download response for the provided row."""
     output = io.StringIO()
     writer = csv.writer(output)
@@ -19,7 +19,7 @@ def csv_response(symbol: str, headers: list[str], row: list) -> 'Response':
     return response
 
 
-def xlsx_response(symbol: str, headers: list[str], row: list) -> 'Response':
+def xlsx_response(symbol: str, headers: list[str], row: list) -> "Response":
     """Return an XLSX file download response for the provided row."""
     output = generate_xlsx(headers, [row])
     response = make_response(output)
@@ -30,7 +30,7 @@ def xlsx_response(symbol: str, headers: list[str], row: list) -> 'Response':
     return response
 
 
-def json_response(symbol: str, data: dict) -> 'Response':
+def json_response(symbol: str, data: dict) -> "Response":
     """Return a JSON download response."""
     response = make_response(json.dumps(data))
     response.headers["Content-Disposition"] = f"attachment; filename={symbol}_data.json"
@@ -38,7 +38,7 @@ def json_response(symbol: str, data: dict) -> 'Response':
     return response
 
 
-def pdf_response(symbol: str, fields: list[tuple[str, str]]) -> 'Response':
+def pdf_response(symbol: str, fields: list[tuple[str, str]]) -> "Response":
     """Return a PDF download response with the provided fields."""
     pdf = FPDF()
     pdf.add_page()


### PR DESCRIPTION
## Summary
- lock Plotly version
- switch docs and build scripts to use `npm ci`
- reformat export helper with black

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6871eeaf4d348326b227390414b29b83