### PR TITLE
Add pre-commit for style checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        args: ["--check"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,12 +25,16 @@ workflow:
    The `package.json` file pins Bootstrap and Plotly versions so `npm ci`
    installs exactly those dependencies for reproducible builds.
 
-3. Run the unit tests and style checks before committing:
+3. Install the git hooks so formatting and linting run automatically:
+
+   ```bash
+   pre-commit install
+   ```
+
+4. Run the unit tests before committing:
 
    ```bash
    pytest
-   black --check .
-   flake8
    ```
 
-4. Open a pull request describing your changes.
+5. Open a pull request describing your changes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pywebpush
 
 black
 flake8
+pre-commit


### PR DESCRIPTION
## Summary
- automate black and flake8 using pre-commit
- document using the hook
- include `pre-commit` in dependencies

## Testing
- `black --check .`
- `flake8` *(failed: command not found)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6871f2039a1483268c67c3db839cc6c0