### PR TITLE
Add validation and error handling for watchlist forms

### DIFF
--- a/stockapp/forms.py
+++ b/stockapp/forms.py
@@ -7,7 +7,7 @@ from wtforms import (
     FileField,
     BooleanField,
 )
-from wtforms.validators import DataRequired, Email, Length, Optional
+from wtforms.validators import DataRequired, Email, Length, Optional, NumberRange
 
 
 class SignupForm(FlaskForm):
@@ -25,10 +25,22 @@ class LoginForm(FlaskForm):
 
 class WatchlistAddForm(FlaskForm):
     symbol = StringField("Symbol", validators=[DataRequired(), Length(max=10)])
-    threshold = FloatField("Threshold", validators=[Optional()])
-    de_threshold = FloatField("D/E Threshold", validators=[Optional()])
-    rsi_threshold = FloatField("RSI Threshold", validators=[Optional()])
-    ma_threshold = FloatField("MA% Threshold", validators=[Optional()])
+    threshold = FloatField(
+        "Threshold",
+        validators=[Optional(), NumberRange(min=0, message="Must be positive")],
+    )
+    de_threshold = FloatField(
+        "D/E Threshold",
+        validators=[Optional(), NumberRange(min=0, message="Must be positive")],
+    )
+    rsi_threshold = FloatField(
+        "RSI Threshold",
+        validators=[Optional(), NumberRange(min=0, max=100, message="0-100")],
+    )
+    ma_threshold = FloatField(
+        "MA% Threshold",
+        validators=[Optional(), NumberRange(min=-100, max=100, message="-100-100")],
+    )
     notes = StringField("Notes", validators=[Optional(), Length(max=200)])
     tags = StringField("Tags", validators=[Optional(), Length(max=100)])
     public = BooleanField("Public")
@@ -36,10 +48,22 @@ class WatchlistAddForm(FlaskForm):
 
 class WatchlistUpdateForm(FlaskForm):
     item_id = IntegerField("Item ID", validators=[DataRequired()])
-    threshold = FloatField("Threshold", validators=[DataRequired()])
-    de_threshold = FloatField("D/E Threshold", validators=[Optional()])
-    rsi_threshold = FloatField("RSI Threshold", validators=[Optional()])
-    ma_threshold = FloatField("MA% Threshold", validators=[Optional()])
+    threshold = FloatField(
+        "Threshold",
+        validators=[DataRequired(), NumberRange(min=0, message="Must be positive")],
+    )
+    de_threshold = FloatField(
+        "D/E Threshold",
+        validators=[Optional(), NumberRange(min=0, message="Must be positive")],
+    )
+    rsi_threshold = FloatField(
+        "RSI Threshold",
+        validators=[Optional(), NumberRange(min=0, max=100, message="0-100")],
+    )
+    ma_threshold = FloatField(
+        "MA% Threshold",
+        validators=[Optional(), NumberRange(min=-100, max=100, message="-100-100")],
+    )
     notes = StringField("Notes", validators=[Optional(), Length(max=200)])
     tags = StringField("Tags", validators=[Optional(), Length(max=100)])
     public = BooleanField("Public")

--- a/stockapp/watchlists/routes.py
+++ b/stockapp/watchlists/routes.py
@@ -30,6 +30,7 @@ watch_bp = Blueprint("watch", __name__)
 def watchlist():
     add_form = WatchlistAddForm()
     update_form = WatchlistUpdateForm()
+    error = None
     if request.method == "POST":
         if request.form.get("item_id"):
             if update_form.validate_on_submit():
@@ -51,6 +52,11 @@ def watchlist():
                     item.tags = tags
                     item.is_public = public
                     db.session.commit()
+            else:
+                error = "; ".join(
+                    f"{getattr(update_form, field).label.text}: {', '.join(msgs)}"
+                    for field, msgs in update_form.errors.items()
+                )
         else:
             if add_form.validate_on_submit():
                 symbol = add_form.symbol.data.upper()
@@ -78,6 +84,11 @@ def watchlist():
                         )
                     )
                     db.session.commit()
+            else:
+                error = "; ".join(
+                    f"{getattr(add_form, field).label.text}: {', '.join(msgs)}"
+                    for field, msgs in add_form.errors.items()
+                )
     items = (
         WatchlistItem.query.filter_by(user_id=current_user.id)
         .order_by(WatchlistItem.symbol)
@@ -96,6 +107,7 @@ def watchlist():
         items=items,
         add_form=add_form,
         update_form=update_form,
+        error=error,
         default_threshold=ALERT_PE_THRESHOLD,
         news=news,
         sentiments=sentiments,

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -5,6 +5,9 @@
 {% block content %}
     <div class="container py-5">
         <h3 class="mb-4">Watchlist</h3>
+        {% if error %}
+        <div class="alert alert-danger">{{ error }}</div>
+        {% endif %}
         <form method="POST" class="mb-3">
             {{ add_form.hidden_tag() }}
             <div class="row g-2 stack-sm">


### PR DESCRIPTION
## Summary
- validate watchlist add/update form inputs using `NumberRange`
- surface form validation errors on the watchlist page
- display errors in the UI for clearer feedback

## Testing
- `black stockapp/forms.py stockapp/watchlists/routes.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687657ca7c3883268b9f74a35e4cd61e