### PR TITLE
Harden production config

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -43,3 +43,7 @@ export REALTIME_PROVIDER="fmp"
 export PRICE_STREAM_INTERVAL=5
 export ASYNC_REALTIME=0
 ```
+
+Do not use the example SMTP or Redis values in a production deployment. Replace
+them with the real connection details for your environment, otherwise the
+application will refuse to start.

--- a/stockapp/config.py
+++ b/stockapp/config.py
@@ -110,6 +110,17 @@ class ProductionConfig(Config):
             raise RuntimeError("SECRET_KEY must be set in production")
         if not os.environ.get("DATABASE_URL"):
             raise RuntimeError("DATABASE_URL must be set in production")
+        if (
+            self.SMTP_SERVER == "smtp.example.com"
+            or self.SMTP_USERNAME == "user@example.com"
+            or self.SMTP_PASSWORD == "password"
+        ):
+            raise RuntimeError("Valid SMTP settings must be provided in production")
+        if (
+            self.CELERY_BROKER_URL == "redis://localhost:6379/0"
+            or self.CELERY_RESULT_BACKEND == "redis://localhost:6379/0"
+        ):
+            raise RuntimeError("Valid Redis settings must be provided in production")
         missing_twilio = [
             var
             for var in ("TWILIO_SID", "TWILIO_TOKEN", "TWILIO_FROM")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,3 +31,33 @@ def test_production_requires_twilio(monkeypatch):
     monkeypatch.delenv("TWILIO_FROM", raising=False)
     with pytest.raises(RuntimeError):
         ProductionConfig()
+
+
+def test_production_requires_smtp(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "secret")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example/db")
+    monkeypatch.setenv("TWILIO_SID", "sid")
+    monkeypatch.setenv("TWILIO_TOKEN", "token")
+    monkeypatch.setenv("TWILIO_FROM", "+1000")
+    monkeypatch.delenv("SMTP_SERVER", raising=False)
+    monkeypatch.delenv("SMTP_USERNAME", raising=False)
+    monkeypatch.delenv("SMTP_PASSWORD", raising=False)
+    monkeypatch.setenv("CELERY_BROKER_URL", "redis://example:6379/1")
+    monkeypatch.setenv("CELERY_RESULT_BACKEND", "redis://example:6379/1")
+    with pytest.raises(RuntimeError):
+        ProductionConfig()
+
+
+def test_production_requires_redis(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "secret")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example/db")
+    monkeypatch.setenv("TWILIO_SID", "sid")
+    monkeypatch.setenv("TWILIO_TOKEN", "token")
+    monkeypatch.setenv("TWILIO_FROM", "+1000")
+    monkeypatch.setenv("SMTP_SERVER", "smtp.mail.com")
+    monkeypatch.setenv("SMTP_USERNAME", "user")
+    monkeypatch.setenv("SMTP_PASSWORD", "pass")
+    monkeypatch.delenv("CELERY_BROKER_URL", raising=False)
+    monkeypatch.delenv("CELERY_RESULT_BACKEND", raising=False)
+    with pytest.raises(RuntimeError):
+        ProductionConfig()


### PR DESCRIPTION
## Summary
- enforce real SMTP and Redis settings for production
- document that the example values must not be used in production
- test SMTP and Redis requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6876d9dd7b1483268a42a5f4df1ad46e