### PR TITLE
Expanded screener filters

### DIFF
--- a/stockapp/screener/routes.py
+++ b/stockapp/screener/routes.py
@@ -13,7 +13,11 @@ def screener():
         "peg_min": request.args.get("peg_min", type=float),
         "peg_max": request.args.get("peg_max", type=float),
         "yield_min": request.args.get("yield_min", type=float),
-        "sector": request.args.get("sector", type=str),
+        "sector": request.args.get("sector") or None,
+        "mc_min": request.args.get("mc_min", type=float),
+        "mc_max": request.args.get("mc_max", type=float),
+        "vol_min": request.args.get("vol_min", type=float),
+        "rating": request.args.get("rating") or None,
     }
     if any(v is not None for v in filters.values()):
         results = screen_stocks(**filters)

--- a/stockapp/utils.py
+++ b/stockapp/utils.py
@@ -1095,6 +1095,10 @@ def screen_stocks(
     peg_max: float | None = None,
     yield_min: float | None = None,
     sector: str | None = None,
+    mc_min: float | None = None,
+    mc_max: float | None = None,
+    vol_min: float | None = None,
+    rating: str | None = None,
 ) -> list[dict]:
     """Return a list of stocks matching the given criteria."""
     if API_KEY_MISSING:
@@ -1109,6 +1113,12 @@ def screen_stocks(
         params["sector"] = sector
     if yield_min is not None:
         params["dividendMoreThan"] = yield_min
+    if mc_min is not None:
+        params["marketCapMoreThan"] = mc_min
+    if mc_max is not None:
+        params["marketCapLowerThan"] = mc_max
+    if vol_min is not None:
+        params["volumeMoreThan"] = vol_min
     query = urllib.parse.urlencode(params)
     url = f"https://financialmodelingprep.com/api/v3/stock-screener?{query}"
     try:
@@ -1129,13 +1139,13 @@ def screen_stocks(
             _currency,
             price,
             eps,
-            _mc,
+            mc_val,
             _de,
             _pb,
             _roe,
             _roa,
             _pm,
-            _rating,
+            analyst_rating,
             dividend_yield,
             _payout,
             earnings_growth,
@@ -1166,6 +1176,11 @@ def screen_stocks(
             dividend_yield is None or dividend_yield * 100 < yield_min
         ):
             continue
+        if rating and (
+            analyst_rating is None
+            or rating.lower() not in str(analyst_rating).lower()
+        ):
+            continue
         results.append(
             {
                 "symbol": symbol,
@@ -1178,6 +1193,9 @@ def screen_stocks(
                     if dividend_yield is not None
                     else None
                 ),
+                "market_cap": mc_val,
+                "volume": item.get("volume"),
+                "analyst_rating": analyst_rating,
             }
         )
     return results

--- a/templates/screener.html
+++ b/templates/screener.html
@@ -28,6 +28,22 @@
             <label class="form-label">{{ _('Sector') }}</label>
             <input type="text" name="sector" class="form-control" value="{{ request.args.get('sector', '') }}">
         </div>
+        <div class="col-md-2">
+            <label class="form-label">{{ _('Min Market Cap') }}</label>
+            <input type="number" step="1" name="mc_min" class="form-control" value="{{ request.args.get('mc_min', '') }}">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">{{ _('Max Market Cap') }}</label>
+            <input type="number" step="1" name="mc_max" class="form-control" value="{{ request.args.get('mc_max', '') }}">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">{{ _('Min Volume') }}</label>
+            <input type="number" step="1" name="vol_min" class="form-control" value="{{ request.args.get('vol_min', '') }}">
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">{{ _('Analyst Rating') }}</label>
+            <input type="text" name="rating" class="form-control" value="{{ request.args.get('rating', '') }}">
+        </div>
         <div class="col-12">
             <button class="btn btn-primary" type="submit">{{ _('Filter') }}</button>
         </div>
@@ -43,6 +59,9 @@
                     <th>{{ _('P/E') }}</th>
                     <th>{{ _('PEG') }}</th>
                     <th>{{ _('Dividend Yield %') }}</th>
+                    <th>{{ _('Market Cap') }}</th>
+                    <th>{{ _('Volume') }}</th>
+                    <th>{{ _('Analyst Rating') }}</th>
                 </tr>
             </thead>
             <tbody>
@@ -54,6 +73,9 @@
                     <td>{{ r.pe }}</td>
                     <td>{{ r.peg }}</td>
                     <td>{{ r.dividend_yield }}</td>
+                    <td>{{ r.market_cap }}</td>
+                    <td>{{ r.volume }}</td>
+                    <td>{{ r.analyst_rating }}</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -9,6 +9,9 @@ def test_screener_route(client, monkeypatch):
                 "pe": 10,
                 "peg": 1.2,
                 "dividend_yield": 2.0,
+                "market_cap": "10B",
+                "volume": 123456,
+                "analyst_rating": "Buy",
             }
         ],
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,3 +42,59 @@ def test_fetch_json_network_error(monkeypatch):
     utils._set_cached("http://test", {"cached": True})
     data = utils._fetch_json("http://test", "desc")
     assert data == {"cached": True}
+
+
+def test_screen_stocks_rating_filter(monkeypatch):
+    monkeypatch.setenv("API_KEY", "x")
+    import stockapp.utils as utils
+
+    importlib.reload(utils)
+
+    monkeypatch.setattr(
+        utils,
+        "_fetch_json",
+        lambda url, desc: [
+            {
+                "symbol": "AAA",
+                "companyName": "Test Co",
+                "sector": "Tech",
+                "pe": 10,
+                "marketCap": 1000,
+                "volume": 1000,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        "stockapp.utils.get_stock_data",
+        lambda symbol: (
+            "Test Co",
+            None,
+            "Tech",
+            "",
+            "",
+            "USD",
+            100,
+            10,
+            "10B",
+            None,
+            None,
+            None,
+            None,
+            None,
+            "Buy",
+            0.02,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+    )
+
+    results = utils.screen_stocks(rating="Buy")
+    assert len(results) == 1 and results[0]["symbol"] == "AAA"
+
+    results = utils.screen_stocks(rating="Sell")
+    assert results == []


### PR DESCRIPTION
## Summary
- extend `screen_stocks` with market cap, volume and rating options
- expose new query parameters in screener route
- display the additional filter controls and columns in the screener template
- cover rating filtering in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6878675653cc8326842649392c98677b