### PR TITLE
Add optional Plaid brokerage provider

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -17,6 +17,7 @@ Copy it to `.env` and adjust as needed. When starting the app these variables ar
 * `REALTIME_PROVIDER` &ndash; Data source for streaming price updates (`fmp` or `yfinance`).
 * `PRICE_STREAM_INTERVAL` &ndash; Seconds between real-time price updates (defaults to `5`).
 * `ASYNC_REALTIME` &ndash; Set to `1` to fetch streaming updates asynchronously.
+* `BROKERAGE_PROVIDER` &ndash; Brokerage integration to use (`basic` or `plaid`).
 
 Example `.env` snippet:
 
@@ -42,6 +43,7 @@ export TWILIO_FROM="+15551234567"
 export REALTIME_PROVIDER="fmp"
 export PRICE_STREAM_INTERVAL=5
 export ASYNC_REALTIME=0
+export BROKERAGE_PROVIDER="basic"
 ```
 
 Do not use the example SMTP or Redis values in a production deployment. Replace

--- a/stockapp/brokerage.py
+++ b/stockapp/brokerage.py
@@ -12,6 +12,14 @@ from typing import List, Dict, Optional
 
 from .utils import session
 
+# Determine which brokerage integration to use. The default "basic"
+# implementation uses the simple stub defined in this module. Setting the
+# ``BROKERAGE_PROVIDER`` environment variable to ``"plaid"`` will delegate to
+# the Plaid stub in ``stockapp.plaid``.
+BROKERAGE_PROVIDER = os.environ.get("BROKERAGE_PROVIDER", "basic").lower()
+if BROKERAGE_PROVIDER == "plaid":
+    from . import plaid
+
 BROKERAGE_CLIENT_ID = os.environ.get("BROKERAGE_CLIENT_ID")
 BROKERAGE_CLIENT_SECRET = os.environ.get("BROKERAGE_CLIENT_SECRET")
 BROKERAGE_AUTH_URL = os.environ.get("BROKERAGE_AUTH_URL")
@@ -117,6 +125,9 @@ def get_holdings(api_token: str) -> List[Dict[str, float]]:
     list of dict
         Each dictionary contains ``symbol``, ``quantity`` and ``price_paid``.
     """
+    if BROKERAGE_PROVIDER == "plaid":
+        return plaid.get_holdings(api_token)
+
     if api_token == "demo-token":
         return [
             {"symbol": "AAA", "quantity": 2, "price_paid": 90},
@@ -145,6 +156,9 @@ def get_transactions(api_token: str) -> List[Dict[str, object]]:
     Each transaction dictionary contains ``symbol``, ``quantity``, ``price``,
     ``type`` and ``timestamp`` keys.
     """
+    if BROKERAGE_PROVIDER == "plaid":
+        return plaid.get_transactions(api_token)
+
     if api_token == "demo-token":
         return [
             {
@@ -170,6 +184,9 @@ def get_transactions(api_token: str) -> List[Dict[str, object]]:
 
 def get_account_balance(api_token: str) -> Optional[float]:
     """Return the account cash balance for the given token."""
+    if BROKERAGE_PROVIDER == "plaid":
+        return plaid.get_account_balance(api_token)
+
     if api_token == "demo-token":
         return 10000.0
     data = _api_get("balance", api_token)

--- a/stockapp/plaid.py
+++ b/stockapp/plaid.py
@@ -1,0 +1,46 @@
+"""Stub functions for Plaid brokerage integration.
+
+These placeholder functions emulate Plaid's API so unit tests can run
+without network access or real credentials.
+"""
+from __future__ import annotations
+from typing import List, Dict, Optional
+
+
+def get_holdings(access_token: str) -> List[Dict[str, float]]:
+    """Return holdings for the given Plaid access token."""
+    if access_token == "demo-plaid-token":
+        return [
+            {"symbol": "AAA", "quantity": 3, "price_paid": 100},
+            {"symbol": "BBB", "quantity": 2, "price_paid": 105},
+        ]
+    return []
+
+
+def get_transactions(access_token: str) -> List[Dict[str, object]]:
+    """Return recent transactions for the given token."""
+    if access_token == "demo-plaid-token":
+        return [
+            {
+                "symbol": "AAA",
+                "quantity": 1,
+                "price": 100,
+                "type": "BUY",
+                "timestamp": "2023-01-01",
+            },
+            {
+                "symbol": "BBB",
+                "quantity": 1,
+                "price": 105,
+                "type": "BUY",
+                "timestamp": "2023-01-02",
+            },
+        ]
+    return []
+
+
+def get_account_balance(access_token: str) -> Optional[float]:
+    """Return the cash balance for the Plaid account."""
+    if access_token == "demo-plaid-token":
+        return 5000.0
+    return None


### PR DESCRIPTION
## Summary
- integrate new BROKERAGE_PROVIDER environment variable
- add Plaid stub implementation for portfolio sync
- test dispatch to Plaid provider
- document BROKERAGE_PROVIDER setting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687868a6f91c8326879ead1c45c4d330