### PR TITLE
Add news summary capability

### DIFF
--- a/stockapp/api/routes.py
+++ b/stockapp/api/routes.py
@@ -1,7 +1,8 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from flask_login import login_required, current_user
 
 from ..models import WatchlistItem, PortfolioItem, Alert
+from ..utils import get_news_summary
 
 api_bp = Blueprint("api", __name__, url_prefix="/api")
 
@@ -62,3 +63,10 @@ def get_alerts():
         for a in alerts
     ]
     return jsonify(data)
+
+
+@api_bp.route("/news_summary/<symbol>")
+def news_summary(symbol: str):
+    period = request.args.get("period", "daily")
+    summary = get_news_summary(symbol.upper(), period)
+    return jsonify({"symbol": symbol.upper(), "summary": summary})

--- a/stockapp/portfolio/helpers.py
+++ b/stockapp/portfolio/helpers.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 from ..extensions import db
 from ..models import PortfolioItem, Transaction, User
-from ..utils import get_locale, convert_currency
+from ..utils import get_locale, convert_currency, summarize_news
 from .. import brokerage
 
 
@@ -399,6 +399,7 @@ def calculate_portfolio_analysis(
         row["item"].symbol: get_stock_news_func(row["item"].symbol, limit=3)
         for row in data
     }
+    news_summaries = {sym: summarize_news(arts) for sym, arts in news_data.items()}
 
     return {
         "data": data,
@@ -413,6 +414,7 @@ def calculate_portfolio_analysis(
         "monte_carlo_var": monte_carlo_var,
         "optimized_allocation": optimized_allocation,
         "news": news_data,
+        "news_summaries": news_summaries,
     }
 
 

--- a/stockapp/portfolio/routes.py
+++ b/stockapp/portfolio/routes.py
@@ -133,6 +133,7 @@ def portfolio() -> str:
         monte_carlo_var=analysis["monte_carlo_var"],
         optimized_allocation=analysis["optimized_allocation"],
         news=analysis["news"],
+        news_summaries=analysis["news_summaries"],
         add_form=add_form,
         import_form=import_form,
         update_form=update_form,

--- a/stockapp/watchlists/routes.py
+++ b/stockapp/watchlists/routes.py
@@ -26,6 +26,7 @@ from ..utils import (
     ALERT_PE_THRESHOLD,
     get_stock_data,
     get_stock_news,
+    summarize_news,
     generate_xlsx,
 )
 from ..forms import WatchlistAddForm, WatchlistUpdateForm
@@ -103,6 +104,7 @@ def watchlist() -> str:
         .all()
     )
     news = {i.symbol: get_stock_news(i.symbol, limit=3) for i in items}
+    summaries = {sym: summarize_news(arts) for sym, arts in news.items()}
     sentiments = {}
     for sym, articles in news.items():
         if articles:
@@ -119,6 +121,7 @@ def watchlist() -> str:
         default_threshold=ALERT_PE_THRESHOLD,
         news=news,
         sentiments=sentiments,
+        summaries=summaries,
     )
 
 

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -103,6 +103,7 @@
             <li><a href="{{ n.url }}" target="_blank">{{ n.headline }}</a> <small class="text-muted">{{ n.published }}</small></li>
             {% endfor %}
         </ul>
+        <p class="text-muted small">{{ news_summaries[sym] }}</p>
         {% endfor %}
         {% endif %}
         {% else %}

--- a/templates/watchlist.html
+++ b/templates/watchlist.html
@@ -80,6 +80,7 @@
                     </li>
                     {% endfor %}
                 </ul>
+                <p class="text-muted small">{{ summaries[item.symbol] }}</p>
                 {% endif %}
             </li>
             {% endfor %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -70,6 +70,10 @@ def test_news_sentiment(monkeypatch):
     assert sentiments[0] > 0
     assert sentiments[1] < 0
 
+    summary = utils.summarize_news(news)
+    assert "2023-01-01" in summary
+    assert "positive" in summary or "negative" in summary
+
 
 def test_api_endpoints(auth_client, app):
     from stockapp.models import WatchlistItem, PortfolioItem, Alert, User
@@ -97,6 +101,10 @@ def test_api_endpoints(auth_client, app):
     resp = auth_client.get("/api/alerts")
     assert resp.status_code == 200
     assert any(alert["message"] == "msg" for alert in resp.get_json())
+
+    resp = auth_client.get("/api/news_summary/API")
+    assert resp.status_code == 200
+    assert "summary" in resp.get_json()
 
 
 def test_stream_price(client, monkeypatch):


### PR DESCRIPTION
## Summary
- generate natural language news summaries
- expose `/api/news_summary/<symbol>` endpoint
- display news summaries on watchlist and portfolio pages
- test news summary helpers and endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68786c56b7a88326b0bdfe0093e56bbf