### PR TITLE
Add background sync and interactive push alerts

### DIFF
--- a/docs/advanced_features.md
+++ b/docs/advanced_features.md
@@ -110,7 +110,12 @@ Opt in from the Settings page. The Celery scheduler sends the summary each morni
 
 A small service worker enables offline caching of static assets so the app behaves like a Progressive Web App.
 Mobile friendly styles and a dark theme are included. Browsers can subscribe to push notifications if VAPID keys
-are configured.
+are configured. The service worker also performs background refreshes of your watchlist using the Sync API so
+data stays up to date even when the app is not open.
+
+Push notifications are interactive – tapping the **Open** action launches the alerts page while **Dismiss** simply
+closes the notification. Background sync events automatically fetch `/api/watchlist` and cache the response for
+faster startup on mobile devices.
 
 ## Frontend Assets
 

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'pe-ratio-cache-v2';
+const CACHE_NAME = 'pe-ratio-cache-v3';
 const urlsToCache = [
   '/static/manifest.json',
   '/static/icons/icon-192.png',
@@ -26,6 +26,18 @@ self.addEventListener('activate', event => {
   );
 });
 
+async function updateData() {
+  try {
+    const resp = await fetch('/api/watchlist', { credentials: 'include' });
+    if (resp.ok) {
+      const cache = await caches.open('data-cache');
+      await cache.put('/api/watchlist', resp.clone());
+    }
+  } catch (e) {
+    console.error('Background data refresh failed', e);
+  }
+}
+
 self.addEventListener('fetch', event => {
   event.respondWith(
     caches.match(event.request)
@@ -39,6 +51,33 @@ self.addEventListener('push', event => {
     try { data = event.data.json(); } catch (e) { data = {body: event.data.text()}; }
   }
   const title = data.title || 'MarketMinder Alert';
-  const options = { body: data.body, icon: '/static/icons/icon-192.png' };
+  const options = {
+    body: data.body,
+    icon: '/static/icons/icon-192.png',
+    actions: data.actions || [
+      { action: 'view', title: 'Open' },
+      { action: 'dismiss', title: 'Dismiss' }
+    ],
+    data: { url: data.url || '/alerts' }
+  };
   event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  if (event.action === 'dismiss') {
+    return;
+  }
+  if (event.action === 'refresh') {
+    event.waitUntil(updateData());
+  } else {
+    const url = event.notification.data && event.notification.data.url;
+    event.waitUntil(clients.openWindow(url || '/'));
+  }
+});
+
+self.addEventListener('sync', event => {
+  if (event.tag === 'refresh-data') {
+    event.waitUntil(updateData());
+  }
 });

--- a/stockapp/utils.py
+++ b/stockapp/utils.py
@@ -385,11 +385,21 @@ def send_push(subscription: "PushSubscription", data: dict) -> None:
 
 
 def notify_user_push(user_id: int, message: str) -> None:
+    from flask import url_for
     from .models import PushSubscription
 
     subs = PushSubscription.query.filter_by(user_id=user_id).all()
+    data = {
+        "title": "MarketMinder Alert",
+        "body": message,
+        "actions": [
+            {"action": "view", "title": "Open"},
+            {"action": "dismiss", "title": "Dismiss"},
+        ],
+        "url": url_for("alerts.alerts", _external=True),
+    }
     for sub in subs:
-        send_push(sub, {"title": "MarketMinder Alert", "body": message})
+        send_push(sub, data)
 
 
 def _get_asx_historical_prices(
@@ -1221,8 +1231,7 @@ def screen_stocks(
         ):
             continue
         if rating and (
-            analyst_rating is None
-            or rating.lower() not in str(analyst_rating).lower()
+            analyst_rating is None or rating.lower() not in str(analyst_rating).lower()
         ):
             continue
         results.append(

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,6 +78,9 @@
                             }
                         });
                     }
+                    if ('sync' in reg && 'SyncManager' in window) {
+                        reg.sync.register('refresh-data');
+                    }
                     if (Notification.permission === 'granted') {
                         subscribe();
                     } else if (Notification.permission === 'default') {


### PR DESCRIPTION
## Summary
- add sync logic and interactive notifications to service worker
- register the sync task in base template
- make push alerts include actions and a link
- document new PWA features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68786f789e7883269012d45e18b01255