### PR TITLE
Add portfolio drawdown & sector correlation metrics

### DIFF
--- a/docs/advanced_features.md
+++ b/docs/advanced_features.md
@@ -83,6 +83,7 @@ These metrics also appear in exported CSV/PDF/XLSX/JSON files.
 
 The portfolio page supports importing and exporting holdings to CSV, XLSX or JSON formats.
 A diversification analyzer highlights concentration risk using metrics like Beta and Sharpe ratio.
+Additional risk statistics including maximum drawdown and sector correlations over configurable periods provide deeper insight into volatility.
 An optimizer suggests asset weights that maximize the Sharpe ratio using recent price data.
 Holdings can also be synced from a brokerage via OAuth when supported.
 

--- a/stockapp/portfolio/routes.py
+++ b/stockapp/portfolio/routes.py
@@ -97,6 +97,11 @@ def sync_brokerage() -> Response:
 @login_required
 def portfolio() -> str:
     symbol_prefill = request.args.get("symbol", "").upper()
+    days = request.args.get("days", "30")
+    try:
+        days_int = int(days)
+    except ValueError:
+        days_int = 30
     add_form = PortfolioAddForm(symbol=symbol_prefill)
     import_form = PortfolioImportForm()
     update_form = PortfolioUpdateForm()
@@ -114,7 +119,7 @@ def portfolio() -> str:
 
     items = PortfolioItem.query.filter_by(user_id=current_user.id).all()
     analysis = calculate_portfolio_analysis(
-        items, get_stock_data, get_historical_prices, get_stock_news
+        items, get_stock_data, get_historical_prices, get_stock_news, days_int
     )
 
     return render_template(
@@ -132,6 +137,9 @@ def portfolio() -> str:
         value_at_risk=analysis["value_at_risk"],
         monte_carlo_var=analysis["monte_carlo_var"],
         optimized_allocation=analysis["optimized_allocation"],
+        maximum_drawdown=analysis["maximum_drawdown"],
+        sector_correlations=analysis["sector_correlations"],
+        sectors=sorted({row["sector"] for row in analysis["data"] if row["sector"]}),
         news=analysis["news"],
         news_summaries=analysis["news_summaries"],
         add_form=add_form,

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -71,6 +71,10 @@
         <h5>Asset Correlations</h5>
         <div id="correlationChart" class="my-4"></div>
         {% endif %}
+        {% if sector_correlations %}
+        <h5>Sector Correlations</h5>
+        <div id="sectorCorrelationChart" class="my-4"></div>
+        {% endif %}
         {% if portfolio_volatility is not none %}
         <div class="alert alert-warning">Portfolio Volatility: {{ portfolio_volatility }}%</div>
         {% endif %}
@@ -85,6 +89,9 @@
         {% endif %}
         {% if monte_carlo_var is not none %}
         <div class="alert alert-danger">Monte Carlo VaR (95%): {{ monte_carlo_var }}</div>
+        {% endif %}
+        {% if maximum_drawdown is not none %}
+        <div class="alert alert-warning">Maximum Drawdown: {{ maximum_drawdown }}%</div>
         {% endif %}
         {% if optimized_allocation %}
         <h5 class="mt-4">Suggested Allocation</h5>
@@ -146,6 +153,31 @@
             colorscale: 'RdBu'
         }];
         Plotly.newPlot('correlationChart', data, {title: 'Correlation Heatmap'});
+    }
+    const sectorCorr = {{ sector_correlations|tojson }};
+    const sectors = {{ sectors|tojson }};
+    if (sectorCorr.length > 0) {
+        const n = sectors.length;
+        const matrix = Array.from({length: n}, () => Array(n).fill(1));
+        sectorCorr.forEach(c => {
+            const parts = c.pair.split('-');
+            const i = sectors.indexOf(parts[0]);
+            const j = sectors.indexOf(parts[1]);
+            if (i > -1 && j > -1) {
+                matrix[i][j] = c.value;
+                matrix[j][i] = c.value;
+            }
+        });
+        const data = [{
+            z: matrix,
+            x: sectors,
+            y: sectors,
+            type: 'heatmap',
+            zmin: -1,
+            zmax: 1,
+            colorscale: 'RdBu'
+        }];
+        Plotly.newPlot('sectorCorrelationChart', data, {title: 'Sector Correlation Heatmap'});
     }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend `calculate_portfolio_analysis` with maximum drawdown and sector correlation calculations
- allow custom period via `days` parameter
- expose new metrics on portfolio page and show new heatmap
- document advanced portfolio analytics
- test new statistics

## Testing
- `black stockapp/portfolio/helpers.py stockapp/portfolio/routes.py tests/test_features.py`
- `python -m flake8 stockapp/portfolio/helpers.py stockapp/portfolio/routes.py tests/test_features.py` *(fails: No module named flake8)*
- `pytest -q` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687d767a7ea8832699ba09958d168fc2