### PR TITLE
Add custom rule backtesting endpoint

### DIFF
--- a/docs/advanced_features.md
+++ b/docs/advanced_features.md
@@ -63,6 +63,15 @@ such as `change('AAPL', 7) > 5` to be notified when Apple rises more than five
 percent over seven days. Expressions evaluate in a restricted context and can
 reference multiple tickers for cross‑asset comparisons.
 
+Rules can be evaluated on past data to see how often they would have
+triggered using the `/api/backtest_rule` endpoint. Provide the rule
+expression and a number of days to test, for example:
+
+```bash
+curl '/api/backtest_rule?rule=change(%27AAPL%27,7)%20%3E%205&days=30'
+```
+
+
 ## Additional Metrics
 
 Alongside the standard P/E ratio the app displays:

--- a/stockapp/api/routes.py
+++ b/stockapp/api/routes.py
@@ -3,6 +3,7 @@ from flask_login import login_required, current_user
 
 from ..models import WatchlistItem, PortfolioItem, Alert
 from ..utils import get_news_summary
+from ..backtesting import backtest_custom_rule
 
 api_bp = Blueprint("api", __name__, url_prefix="/api")
 
@@ -70,3 +71,19 @@ def news_summary(symbol: str):
     period = request.args.get("period", "daily")
     summary = get_news_summary(symbol.upper(), period)
     return jsonify({"symbol": symbol.upper(), "summary": summary})
+
+
+@api_bp.route("/backtest_rule")
+@login_required
+def api_backtest_rule():
+    """Return historical evaluation of a custom rule."""
+    rule = request.args.get("rule", "")
+    days_param = request.args.get("days", "30")
+    try:
+        days = int(days_param)
+    except ValueError:
+        days = 30
+    if not rule:
+        return jsonify({"error": "rule required"}), 400
+    results = backtest_custom_rule(rule, days)
+    return jsonify({"rule": rule, "results": results})

--- a/stockapp/backtesting.py
+++ b/stockapp/backtesting.py
@@ -1,0 +1,68 @@
+import re
+from typing import Any
+
+from .utils import get_historical_prices
+
+
+def backtest_custom_rule(rule: str, days: int = 30) -> list[dict[str, Any]]:
+    """Evaluate a custom rule over historical data.
+
+    Returns a list of dictionaries with ``date`` and ``result`` keys.
+    ``days`` controls how many days are tested counting back from the
+    most recent historical record.
+    """
+
+    # Extract symbols and maximum change window from the rule
+    symbol_pattern = re.compile(r"(?:price|change)\(\s*['\"]([^'\"]+)['\"]")
+    change_pattern = re.compile(r"change\(\s*['\"][^'\"]+['\"],\s*(\d+)\s*\)")
+
+    symbols = set(symbol_pattern.findall(rule))
+    max_days = 0
+    for m in change_pattern.findall(rule):
+        try:
+            max_days = max(max_days, int(m))
+        except ValueError:
+            pass
+
+    if not symbols:
+        return []
+
+    history: dict[str, tuple[list[str], list[float]]] = {}
+    for sym in symbols:
+        dates, prices = get_historical_prices(sym, days=days + max_days)
+        history[sym] = (dates, prices)
+
+    if not history:
+        return []
+
+    min_len = min(len(p[1]) for p in history.values())
+    results: list[dict[str, Any]] = []
+
+    for idx in range(max_days, min(max_days + days, min_len)):
+        def price_fn(symbol: str) -> float | None:
+            ds, ps = history.get(symbol, ([], []))
+            if idx < len(ps):
+                return ps[idx]
+            return None
+
+        def change_fn(symbol: str, window: int) -> float | None:
+            ds, ps = history.get(symbol, ([], []))
+            if idx < len(ps) and idx - window >= 0:
+                start = ps[idx - window]
+                end = ps[idx]
+                if start and end:
+                    try:
+                        return round((end - start) / start * 100, 2)
+                    except Exception:
+                        return None
+            return None
+
+        try:
+            result = bool(eval(rule, {"__builtins__": {}}, {"price": price_fn, "change": change_fn}))
+        except Exception:
+            result = False
+
+        date = next(iter(history.values()))[0][idx] if history else ""
+        results.append({"date": date, "result": result})
+
+    return results

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+def test_backtest_rule_api(auth_client, monkeypatch):
+    # Provide deterministic historical prices
+    def fake_hist(symbol, days=10):
+        dates = [f"d{i}" for i in range(days)]
+        prices = [100 + i * 10 for i in range(days)]
+        return dates, prices
+
+    monkeypatch.setattr("stockapp.backtesting.get_historical_prices", fake_hist)
+
+    resp = auth_client.get("/api/backtest_rule?rule=change('AAA',3)%20>%205&days=5")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["results"]) == 5
+    assert all(r["result"] for r in data["results"])


### PR DESCRIPTION
## Summary
- implement historical backtesting for custom rules
- expose `/api/backtest_rule` endpoint
- document the feature
- test rule backtesting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687d783a20ec8326995d8947c3ea9195