### PR TITLE
Add dynamic brokerage providers with Alpaca stub

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -18,7 +18,7 @@ Copy it to `.env` and adjust as needed. When starting the app these variables ar
 * `REALTIME_PROVIDER` &ndash; Data source for streaming price updates (`fmp` or `yfinance`).
 * `PRICE_STREAM_INTERVAL` &ndash; Seconds between real-time price updates (defaults to `5`).
 * `ASYNC_REALTIME` &ndash; Set to `1` to fetch streaming updates asynchronously.
-* `BROKERAGE_PROVIDER` &ndash; Brokerage integration to use (`basic` or `plaid`).
+* `BROKERAGE_PROVIDER` &ndash; Brokerage integration to use (`basic`, `plaid` or `alpaca`).
 
 Example `.env` snippet:
 

--- a/stockapp/alpaca.py
+++ b/stockapp/alpaca.py
@@ -1,0 +1,77 @@
+"""Minimal Alpaca brokerage integration stub."""
+
+from __future__ import annotations
+from typing import List, Dict, Optional
+import os
+
+from .utils import session
+
+ALPACA_API_BASE = os.environ.get("ALPACA_API_BASE")
+
+
+def _api_get(path: str, token: str) -> Optional[Dict[str, object]]:
+    if not ALPACA_API_BASE:
+        return None
+    try:
+        resp = session.get(
+            f"{ALPACA_API_BASE.rstrip('/')}/{path.lstrip('/')}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        return None
+
+
+def get_holdings(access_token: str) -> List[Dict[str, float]]:
+    """Return holdings for the given Alpaca access token."""
+    if access_token == "demo-alpaca-token":
+        return [
+            {"symbol": "AAA", "quantity": 5, "price_paid": 100},
+            {"symbol": "BBB", "quantity": 2, "price_paid": 105},
+        ]
+    data = _api_get("positions", access_token)
+    if isinstance(data, list):
+        result = []
+        for h in data:
+            symbol = h.get("symbol", "").upper()
+            try:
+                qty = float(h.get("qty", h.get("quantity", 0)))
+                price = float(h.get("avg_entry_price", h.get("price_paid", 0)))
+            except Exception:
+                continue
+            result.append({"symbol": symbol, "quantity": qty, "price_paid": price})
+        return result
+    return []
+
+
+def get_transactions(access_token: str) -> List[Dict[str, object]]:
+    """Return recent trade activities."""
+    if access_token == "demo-alpaca-token":
+        return [
+            {
+                "symbol": "AAA",
+                "quantity": 1,
+                "price": 101,
+                "type": "BUY",
+                "timestamp": "2023-01-03",
+            },
+        ]
+    data = _api_get("activities", access_token)
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def get_account_balance(access_token: str) -> Optional[float]:
+    """Return the cash balance for the account."""
+    if access_token == "demo-alpaca-token":
+        return 2500.0
+    data = _api_get("account", access_token)
+    if isinstance(data, dict):
+        try:
+            return float(data.get("cash", data.get("cash_balance", 0)))
+        except Exception:
+            return None
+    return None

--- a/tests/test_brokerage.py
+++ b/tests/test_brokerage.py
@@ -32,10 +32,24 @@ def test_plaid_provider(monkeypatch):
     importlib.reload(brok)
 
     called = {}
-    monkeypatch.setattr(brok.plaid, "get_holdings", lambda t: called.setdefault("holdings", t) or [])
+    monkeypatch.setattr(brok.provider, "get_holdings", lambda t: called.setdefault("holdings", t) or [])
     brok.get_holdings("demo-plaid-token")
     assert called.get("holdings") == "demo-plaid-token"
 
-    # reset to default for other tests
+    monkeypatch.setitem(os.environ, "BROKERAGE_PROVIDER", "basic")
+    importlib.reload(brok)
+
+
+def test_alpaca_provider(monkeypatch):
+    import importlib
+    monkeypatch.setitem(os.environ, "BROKERAGE_PROVIDER", "alpaca")
+    import stockapp.brokerage as brok
+    importlib.reload(brok)
+
+    called = {}
+    monkeypatch.setattr(brok.provider, "get_holdings", lambda t: called.setdefault("holdings", t) or [])
+    brok.get_holdings("demo-alpaca-token")
+    assert called.get("holdings") == "demo-alpaca-token"
+
     monkeypatch.setitem(os.environ, "BROKERAGE_PROVIDER", "basic")
     importlib.reload(brok)


### PR DESCRIPTION
## Summary
- add new Alpaca brokerage provider stub
- dynamically import brokerage providers instead of only Plaid
- allow selecting `alpaca` via `BROKERAGE_PROVIDER`
- document provider option in env docs
- test that Plaid and Alpaca providers are loaded

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687d7f23f1d88326a03a80b837406a74