### PR TITLE
Add real-time dashboard

### DIFF
--- a/stockapp/main/routes.py
+++ b/stockapp/main/routes.py
@@ -667,3 +667,41 @@ def download() -> Response | tuple[str, int]:
         return pdf_response(symbol, fields)
     else:
         return "Invalid format", 400
+
+
+@main_bp.route("/dashboard")
+def dashboard() -> str:
+    """Display real-time price chart with candlestick overlay."""
+    symbol = request.args.get("symbol", "").upper()
+    dates = opens = highs = lows = closes = []
+    price = eps = pe_ratio = None
+    if symbol:
+        try:
+            (
+                _name,
+                _logo,
+                _sector,
+                _industry,
+                _exchange,
+                _currency,
+                price,
+                eps,
+                *_rest,
+            ) = get_stock_data(symbol)
+            dates, opens, highs, lows, closes = get_historical_ohlc(symbol, days=60)
+            if price is not None and eps:
+                pe_ratio = round(price / eps, 2)
+        except Exception:
+            symbol = ""
+    return render_template(
+        "dashboard.html",
+        symbol=symbol,
+        price=price,
+        eps=eps,
+        pe_ratio=pe_ratio,
+        dates=dates,
+        opens=opens,
+        highs=highs,
+        lows=lows,
+        closes=closes,
+    )

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,6 +34,7 @@
                         <a href="{{ url_for('watch.records') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Records') }}</a>
                         <a href="{{ url_for('watch.export_history') }}" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">{{ _('Export History') }}</a>
                         <a href="{{ url_for('screener.screener') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Screener') }}</a>
+                        <a href="{{ url_for('main.dashboard') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">Dashboard</a>
                         <a href="{{ url_for('calc.interest') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Calculators') }}</a>
                         <a href="{{ url_for('watch.settings') }}" class="btn btn-sm btn-outline-secondary me-2 mb-2 mb-lg-0">{{ _('Settings') }}</a>
                         <form method="post" action="{{ url_for('watch.toggle_theme') }}" class="d-inline">
@@ -48,6 +49,7 @@
                     <div class="ms-auto d-lg-flex align-items-center">
                         <a href="{{ url_for('portfolio.leaderboard') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Leaderboard') }}</a>
                         <a href="{{ url_for('screener.screener') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Screener') }}</a>
+                        <a href="{{ url_for('main.dashboard') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">Dashboard</a>
                         <a href="{{ url_for('auth.login') }}" class="btn btn-sm btn-outline-primary me-2 mb-2 mb-lg-0">{{ _('Login') }}</a>
                         <a href="{{ url_for('auth.signup') }}" class="btn btn-sm btn-outline-secondary mb-2 mb-lg-0">{{ _('Sign Up') }}</a>
                     </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+
+{% block head %}
+    <script src="{{ url_for('static', filename='vendor/plotly.min.js') }}"></script>
+{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <h3 class="mb-4">Real-Time Dashboard</h3>
+    <form method="get" class="row g-2 mb-3">
+        <div class="col-auto">
+            <input type="text" name="symbol" class="form-control" placeholder="Symbol" value="{{ symbol }}" required>
+        </div>
+        <div class="col-auto">
+            <button class="btn btn-primary" type="submit">Load</button>
+        </div>
+    </form>
+    {% if symbol %}
+    <p>Price: <span id="rt_price">{{ price }}</span>
+        {% if pe_ratio is not none %}| P/E: <span id="rt_pe">{{ pe_ratio }}</span>{% endif %}
+    </p>
+    <div id="rt_chart"></div>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block scripts %}
+{% if symbol %}
+<script>
+const dates = {{ dates|tojson }};
+const opens = {{ opens|tojson }};
+const highs = {{ highs|tojson }};
+const lows = {{ lows|tojson }};
+const closes = {{ closes|tojson }};
+const rtTimes = [];
+const rtPrices = [];
+
+const candle = { x: dates, open: opens, high: highs, low: lows, close: closes, type: 'candlestick', name: 'History' };
+const live = { x: rtTimes, y: rtPrices, mode: 'lines', name: 'Live Price' };
+
+Plotly.newPlot('rt_chart', [candle, live], { title: '{{ symbol }}', xaxis: { title: 'Time' }, yaxis:{ title: 'Price' } });
+
+const ws = new WebSocket("{{ url_for('main.ws_price') }}");
+ws.onopen = () => { ws.send("{{ symbol }}"); };
+ws.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+    if (data.price !== undefined) {
+        document.getElementById('rt_price').textContent = data.price;
+        {% if eps %}
+        if (data.eps) document.getElementById('rt_pe').textContent = (data.price / data.eps).toFixed(2);
+        {% endif %}
+        rtTimes.push(new Date());
+        rtPrices.push(data.price);
+        Plotly.update('rt_chart', { x: [rtTimes], y: [rtPrices] }, {}, [1]);
+    }
+};
+</script>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/dashboard` route to show real-time price chart
- create dashboard template using Plotly and WebSocket updates
- link to dashboard in the navigation menu

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687d810471508326b443064261a4bf41