### PR TITLE
Add PDF export options

### DIFF
--- a/docs/advanced_features.md
+++ b/docs/advanced_features.md
@@ -100,7 +100,8 @@ These metrics also appear in exported CSV/PDF/XLSX/JSON files.
 
 ## Portfolio Import and Export
 
-The portfolio page supports importing and exporting holdings to CSV, XLSX or JSON formats.
+The portfolio page supports importing and exporting holdings to CSV, XLSX, JSON or PDF formats.
+Watchlist history exports share the same options for generating periodic reports.
 A diversification analyzer highlights concentration risk using metrics like Beta and Sharpe ratio.
 Additional risk statistics including maximum drawdown and sector correlations over configurable periods provide deeper insight into volatility.
 An optimizer suggests asset weights that maximize the Sharpe ratio using recent price data.

--- a/stockapp/portfolio/routes.py
+++ b/stockapp/portfolio/routes.py
@@ -11,6 +11,7 @@ from flask_login import login_required, current_user
 import csv
 import io
 import json
+from fpdf import FPDF
 
 from ..extensions import db
 from ..models import (
@@ -83,6 +84,23 @@ def export_portfolio() -> Response | tuple[str, int]:
         response = make_response(json.dumps(data))
         response.headers["Content-Disposition"] = "attachment; filename=portfolio.json"
         response.headers["Content-Type"] = "application/json"
+        return response
+    elif fmt == "pdf":
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        pdf.cell(0, 10, txt="Portfolio", ln=1)
+        pdf.cell(60, 10, txt="Symbol", border=1)
+        pdf.cell(40, 10, txt="Quantity", border=1)
+        pdf.cell(40, 10, txt="Price Paid", border=1, ln=1)
+        for item in items:
+            pdf.cell(60, 10, txt=str(item.symbol), border=1)
+            pdf.cell(40, 10, txt=str(item.quantity), border=1)
+            pdf.cell(40, 10, txt=str(item.price_paid), border=1, ln=1)
+        pdf_output = pdf.output(dest="S").encode("latin-1")
+        response = make_response(pdf_output)
+        response.headers["Content-Disposition"] = "attachment; filename=portfolio.pdf"
+        response.headers["Content-Type"] = "application/pdf"
         return response
     else:
         return "Invalid format", 400

--- a/stockapp/watchlists/routes.py
+++ b/stockapp/watchlists/routes.py
@@ -12,6 +12,7 @@ import csv
 import io
 import json
 from babel.dates import format_datetime
+from fpdf import FPDF
 
 from ..extensions import db
 
@@ -293,6 +294,22 @@ def export_history() -> Response | tuple[str, int]:
         response = make_response(json.dumps(data))
         response.headers["Content-Disposition"] = "attachment; filename=history.json"
         response.headers["Content-Type"] = "application/json"
+        return response
+    elif fmt == "pdf":
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        pdf.cell(0, 10, txt="Watchlist History", ln=1)
+        pdf.cell(60, 10, txt="Symbol", border=1)
+        pdf.cell(80, 10, txt="Timestamp", border=1, ln=1)
+        for e in entries:
+            pdf.cell(60, 10, txt=str(e.symbol), border=1)
+            timestamp = format_datetime(e.timestamp, locale=get_locale())
+            pdf.cell(80, 10, txt=timestamp, border=1, ln=1)
+        pdf_output = pdf.output(dest="S").encode("latin-1")
+        response = make_response(pdf_output)
+        response.headers["Content-Disposition"] = "attachment; filename=history.pdf"
+        response.headers["Content-Type"] = "application/pdf"
         return response
     else:
         return "Invalid format", 400

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -192,6 +192,37 @@ def test_export_portfolio_json(auth_client, app):
     assert resp.headers["Content-Type"] == "application/json"
 
 
+def test_export_portfolio_pdf(auth_client, app):
+    from stockapp.models import User, PortfolioItem
+    from stockapp.extensions import db
+
+    with app.app_context():
+        user = User.query.filter_by(username="tester").first()
+        db.session.add(
+            PortfolioItem(symbol="DDD", quantity=4, price_paid=40, user_id=user.id)
+        )
+        db.session.commit()
+    resp = auth_client.get("/export_portfolio?format=pdf")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "application/pdf"
+
+
+def test_export_history_pdf(auth_client, app):
+    from stockapp.models import User, History
+    from stockapp.extensions import db
+    from datetime import datetime
+
+    with app.app_context():
+        user = User.query.filter_by(username="tester").first()
+        db.session.add(
+            History(symbol="EEE", user_id=user.id, timestamp=datetime.utcnow())
+        )
+        db.session.commit()
+    resp = auth_client.get("/export_history?format=pdf")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "application/pdf"
+
+
 def test_roi_calculator(client):
     data = {"initial": 100, "final": 120}
     resp = client.post("/calc/roi", data=data)


### PR DESCRIPTION
## Summary
- allow portfolio and watchlist history to be exported as PDF
- document PDF export capability in advanced features guide
- cover PDF exports in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687d8422e0e48326a8ea34eea2933e04